### PR TITLE
Resolve issues and best practice violations found while testing 1.2.0...

### DIFF
--- a/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBasedRepositoryMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBasedRepositoryMojo.java
@@ -168,7 +168,7 @@ public abstract class AbstractGitflowBasedRepositoryMojo extends AbstractGitflow
      * group:artifact:type:classifier:version
      */
     protected void attachArtifactCatalog() throws MojoExecutionException {
-            getLog().debug("Cataloging Artifacts for promotion & reattachment: " + project.getBuild().getDirectory());
+            getLog().info("Cataloging Artifacts for promotion & reattachment: " + project.getBuild().getDirectory());
 
             File catalog = new File(buildDirectory, project.getArtifact().getArtifactId() + ".txt");
 

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBasedRepositoryMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBasedRepositoryMojo.java
@@ -226,7 +226,7 @@ public abstract class AbstractGitflowBasedRepositoryMojo extends AbstractGitflow
             if (disableLocal == true) {
                 throw new MojoExecutionException("Cannot resolve artifacts from 'null' repository if the local repository is also disabled.");
             }
-            getLog().debug("Attaching existing artifacts from local repository only.");
+            getLog().debug("Resolving existing artifacts from local repository only.");
         } else {
             // Add the remote repository.
             remoteRepositories.addAll(Arrays.asList(getRepository(sourceRepository)));
@@ -239,7 +239,7 @@ public abstract class AbstractGitflowBasedRepositoryMojo extends AbstractGitflow
         Field localBaseDir = null;
         File originalBaseDir = session.getLocalRepositoryManager().getRepository().getBasedir();
 
-        // Disable the local repository.
+        // Disable the local repository - using a bit of reflection that I wish we didn't need to use.
         File tempRepo = null;
         if (disableLocal) {
             getLog().info("Disabling local repository @ " + session.getLocalRepository().getBasedir());
@@ -322,7 +322,7 @@ public abstract class AbstractGitflowBasedRepositoryMojo extends AbstractGitflow
             }
         }
 
-        // Restore the local repository.
+        // Restore the local repository, again using reflection.
         if (disableLocal) {
             try {
                 localBaseDir.set(session.getLocalRepositoryManager().getRepository(), originalBaseDir);

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBranchMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBranchMojo.java
@@ -78,7 +78,7 @@ public abstract class AbstractGitflowBranchMojo extends AbstractMojo {
         ExpansionBuffer eb = new ExpansionBuffer(gitBranch);
 
         if (!gitBranchExpression.equals(gitBranch) || getLog().isDebugEnabled()) { // Resolves Issue #9
-            getLog().info("Resolved gitBranchExpression: '" + gitBranchExpression + " to '" + gitBranch + "'");
+            getLog().debug("Resolved gitBranchExpression: '" + gitBranchExpression + " to '" + gitBranch + "'");
         }
 
         if (!eb.hasMoreLegalPlaceholders()) {

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/AttachDeployedArtifactsMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/AttachDeployedArtifactsMojo.java
@@ -1,15 +1,10 @@
 package com.e_gineering.maven.gitflowhelper;
 
-import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.codehaus.plexus.util.FileUtils;
-
-import java.io.File;
-import java.io.IOException;
 
 /**
  * When executed, attaches artifacts from a previously deployed (to a repository) build of this
@@ -43,21 +38,6 @@ public class AttachDeployedArtifactsMojo extends AbstractGitflowBasedRepositoryM
                 // Use the 'local' repository to do this.
                 attachExistingArtifacts(null, false);
             }
-        }
-
-        File targetDir = new File(project.getBuild().getDirectory());
-        for (Artifact artifact : project.getAttachedArtifacts()) {
-            try {
-                FileUtils.copyFileToDirectory(artifact.getFile(), targetDir);
-            } catch (IOException ioe) {
-                throw new MojoExecutionException("Failed to copy attached artifact to output directory.", ioe);
-            }
-        }
-
-        try {
-            FileUtils.copyFile(project.getArtifact().getFile(), new File(targetDir, project.getBuild().getFinalName() + "." + FileUtils.getExtension(project.getArtifact().getFile().getName())));
-        } catch (IOException ioe) {
-            throw new MojoExecutionException("Failed to copy project artifact to: " + project.getBuild().getFinalName() + "." + FileUtils.getExtension(project.getArtifact().getFile().getName()), ioe);
         }
     }
 }

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/PromoteMasterMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/PromoteMasterMojo.java
@@ -23,11 +23,13 @@ public class PromoteMasterMojo extends AbstractGitflowBasedRepositoryMojo {
             case DEVELOPMENT:
             case RELEASE:
             case HOTFIX: {
+                // In order to use promote-master or attach-deployed, we need to build an artifactCatalog on deliverable branches.
                 attachArtifactCatalog();
                 break;
             }
+
             case MASTER: {
-                getLog().info("Attaching existing artifacts from stageDeploymentRepository [" + stageDeploymentRepository + "]");
+                getLog().info("Resolving & Reattaching existing artifacts from stageDeploymentRepository [" + stageDeploymentRepository + "]");
 
                 attachExistingArtifacts(stageDeploymentRepository, true);
 


### PR DESCRIPTION
* Update primary artifact rather than attach duplicates.
* Inject the buildDirectory path.
* Use UTF-8 for catalog files (fixes platform dependence)
* More robust handling of file extension / type for poorly defined package types (mulesoft)
* Better handling for temproary files / directories (follows the maven guidelines for not using JVM hooks)
* Proper handling for directory creation, using absolute paths.
* Centralized artifact copying to build directory & attached artifact updating.