### PR TITLE
Hotfix 1.2.1 - Forgot an important piece of the puzzle...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.e-gineering</groupId>
     <artifactId>gitflow-helper-maven-plugin</artifactId>
 
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <packaging>maven-plugin</packaging>
 
     <name>gitflow-helper-maven-plugin</name>

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/MasterPromoteExtension.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/MasterPromoteExtension.java
@@ -26,6 +26,8 @@ public class MasterPromoteExtension extends AbstractMavenLifecycleParticipant {
     @Requirement
     private Logger logger;
 
+
+
     @Override
     public void afterProjectsRead(MavenSession session) throws MavenExecutionException {
         Properties systemEnvVars = null;
@@ -37,6 +39,7 @@ public class MasterPromoteExtension extends AbstractMavenLifecycleParticipant {
 
         // Look for a gitflow-helper-maven-plugin, so we can determine what the gitBranchExpression and masterBranchPattern are...
         String masterBranchPattern = null;
+
         String gitBranchExpression = null;
         boolean pluginFound = false;
 
@@ -47,27 +50,21 @@ public class MasterPromoteExtension extends AbstractMavenLifecycleParticipant {
             List<Plugin> dropPlugins = new ArrayList<Plugin>();
 
             for (Plugin plugin : project.getBuildPlugins()) {
-                // Don't drop our plugin. Read it's config.
+                // Don't drop our plugin. Read it's config
                 if (plugin.getKey().equals("com.e-gineering:gitflow-helper-maven-plugin")) {
                     pluginFound = true;
 
                     logger.debug("gitflow-helper-maven-plugin found in project: [" + project.getName() + "]");
 
                     if (masterBranchPattern == null) {
-                        masterBranchPattern = extractMasterBranchPattern(plugin.getConfiguration());
-                        for (int i = 0; i < plugin.getExecutions().size() && masterBranchPattern == null; i++) {
-                            masterBranchPattern = extractMasterBranchPattern(plugin.getExecutions().get(i).getConfiguration());
-                        }
+                        masterBranchPattern = extractPluginConfigValue("masterBranchPattern", plugin);
                     }
 
                     if (gitBranchExpression == null) {
-                        gitBranchExpression = extractGitBranchExpression(plugin.getConfiguration());
-                        for (int i = 0; i < plugin.getExecutions().size() && gitBranchExpression == null; i++) {
-                            gitBranchExpression = extractGitBranchExpression(plugin.getExecutions().get(i).getConfiguration());
-                        }
+                        gitBranchExpression = extractPluginConfigValue("gitBranchExpression", plugin);
                     }
 
-                    // Don't drop the maven-deploy-plugin. Read it's config.
+                    // Don't drop the maven-deploy-plugin
                 } else if (plugin.getKey().equals("org.apache.maven.plugins:maven-deploy-plugin")) {
                     logger.debug("gitflow-helper-maven-plugin removing plugin: " + plugin + " from project: " + project.getName());
                 } else {
@@ -108,17 +105,17 @@ public class MasterPromoteExtension extends AbstractMavenLifecycleParticipant {
         }
     }
 
-    private String extractMasterBranchPattern(Object configuration) {
-        try {
-            return ((Xpp3Dom) configuration).getChild("masterBranchPattern").getValue();
-        } catch (Exception ex) {
+    private String extractPluginConfigValue(String parameter, Plugin plugin) {
+        String value = extractConfigValue(parameter, plugin.getConfiguration());
+        for (int i = 0; i < plugin.getExecutions().size() && value == null; i++) {
+            value = extractConfigValue(parameter, plugin.getExecutions().get(i).getConfiguration());
         }
-        return null;
+        return value;
     }
 
-    private String extractGitBranchExpression(Object configuration) {
+    private String extractConfigValue(String parameter, Object configuration) {
         try {
-            return ((Xpp3Dom) configuration).getChild("gitBranchExpression").getValue();
+            return ((Xpp3Dom) configuration).getChild(parameter).getValue();
         } catch (Exception ex) {
         }
         return null;

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/MasterPromoteExtension.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/MasterPromoteExtension.java
@@ -26,8 +26,6 @@ public class MasterPromoteExtension extends AbstractMavenLifecycleParticipant {
     @Requirement
     private Logger logger;
 
-
-
     @Override
     public void afterProjectsRead(MavenSession session) throws MavenExecutionException {
         Properties systemEnvVars = null;

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/RetargetDeployMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/RetargetDeployMojo.java
@@ -43,9 +43,11 @@ public class RetargetDeployMojo extends AbstractGitflowBasedRepositoryMojo {
                 break;
             }
             default: {
-                getLog().info("Un-Setting artifact repositories");
+                getLog().info("Un-Setting artifact repositories.");
                 project.setSnapshotArtifactRepository(null);
                 project.setReleaseArtifactRepository(null);
+                project.getProperties().put("maven.deploy.skip", "true");
+                getLog().info("Setting maven.deploy.skip = 'true'");
                 break;
             }
         }


### PR DESCRIPTION
* If doing builds locally, or on a feature / bugfix branch in a CI job, we need to skip the actual 'deploy' step. The primary method of doing this is to set `maven.deploy.skip=true`
* Refactored (generalized) configuration scanning in the build extension, which is what's responsible for removing plugins we don't want to run in 'master'.

The assumption is that we only ever want to run our own plugins in the master branch. This should probably be configurable, but I'm waiting for a 'valid' use case to emerge before I create an issue for that.