### PR TITLE
Don't fail the build when GIT_BRANCH is unset and it's a non-snapshot build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.e-gineering</groupId>
     <artifactId>gitflow-helper-maven-plugin</artifactId>
 
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <packaging>maven-plugin</packaging>
 
     <name>gitflow-helper-maven-plugin</name>

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBranchMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBranchMojo.java
@@ -102,7 +102,7 @@ public abstract class AbstractGitflowBranchMojo extends AbstractMojo {
                 logExecute(GitBranchType.OTHER, gitBranch, null);
             }
         } else {
-            logExecute(GitBranchType.OTHER, gitBranch, null);
+            logExecute(GitBranchType.UNDEFINED, gitBranch, null);
         }
     }
 }

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/EnforceVersionsMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/EnforceVersionsMojo.java
@@ -38,7 +38,7 @@ public class EnforceVersionsMojo extends AbstractGitflowBranchMojo {
                     }
                 }
             }
-        } else { // Unversioned branch type. Must be -SNAPSHOT.
+        } else if (!type.equals(GitBranchType.UNDEFINED)) { // Unversioned branch type. Must be -SNAPSHOT.
             if (!ArtifactUtils.isSnapshot(project.getVersion())) {
                 throw new MojoFailureException("Builds from non-release git branches must end with -SNAPSHOT");
             }

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/GitBranchType.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/GitBranchType.java
@@ -9,5 +9,6 @@ public enum GitBranchType {
     HOTFIX,
     BUGFIX,
     DEVELOPMENT,
-    OTHER;
+    OTHER,
+    UNDEFINED;
 }


### PR DESCRIPTION
When the branch is UNDEFINED, you're likely building locally.

In that case, you may want to build a release branch, but won't have a GIT_BRANCH environment variable to set set the branch. Previously this would have failed the build, as the version would have been a non-snapshot.

This change introduces the UNDEFINED git branch type, so that enforce-versions won't fail the build for local builds of release (or any other) branch.