### PR TITLE
Hotfix/1.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ One common stumbling block for teams adjusting to gitflow with Maven projects is
 In practice, the Maven versions should:
  
  * Be synchronized with release branch and hotfix branch names.
- * Never be -SNAPSHOT in the master branch, release, hotfix, or bugfix branches.
- * Always be -SNAPSHOT in the development or feature branches.
+ * Never be -SNAPSHOT in the master branch, release, or hotfix branches.
+ * Always be -SNAPSHOT in the development branch.
  * Be irrelevant if there's no git branch resolvable from your environment.
 
 The `enforce-versions` goal asserts these semantics when it can resolve the `gitBranchExpression`.
@@ -96,7 +96,6 @@ The following properties change the behavior of this goal:
 | masterBranchPattern  | origin/master | No | Regex. When matched, signals the master branch is being built. Note the lack of a subgroup. |
 | releaseBranchPattern | origin/release/(.*) | No | Regex. When matched, signals a release branch being built. Subgroup 1, if present, must match the Maven project version. |
 | hotfixBranchPattern  | origin/hotfix/(.*) | No | Regex. When matched, signals a hotfix branch is being built. Subgroup 1, if present, must match the Maven project version. |
-| bugfixBranchPattern  | origin/bugfix/.* | No | Regex. When matched, signals a bugfix branch is being built. Note the lack of a subgroup. |
 | developmentBranchPattern | origin/development | Yes | Regex. When matched, signals a development branch is being built. Note the lack of a subgroup. |
 
 ## Goal: `retarget-deploy` (Branch Specific Deploy Targets & Staging)
@@ -240,7 +239,6 @@ The following table describes the git branch expression -> repository used for r
 | masterBranchPattern   | release    |
 | releaseBranchPattern  | stage      |
 | hotfixBranchPattern   | stage      |
-| bugfixBranchPattern   | stage      |
 | developmentBranchPattern | snapshots | 
 | All Others            | local      |
  

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.e-gineering</groupId>
     <artifactId>gitflow-helper-maven-plugin</artifactId>
 
-    <version>1.2.2</version>
+    <version>1.2.3</version>
     <packaging>maven-plugin</packaging>
 
     <name>gitflow-helper-maven-plugin</name>

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBranchMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBranchMojo.java
@@ -35,9 +35,6 @@ public abstract class AbstractGitflowBranchMojo extends AbstractMojo {
     @Parameter(defaultValue = "origin/hotfix/(.*)", property = "hotfixBranchPattern", required = true)
     private String hotfixBranchPattern;
 
-    @Parameter(defaultValue = "origin/bugfix/.*", property = "bugfixBranchPattern", required = true)
-    private String bugfixBranchPattern;
-
     @Parameter(defaultValue = "origin/development", property = "developmentBranchPattern", required = true)
     private String developmentBranchPattern;
 
@@ -94,8 +91,6 @@ public abstract class AbstractGitflowBranchMojo extends AbstractMojo {
                 logExecute(GitBranchType.RELEASE, gitBranch, releaseBranchPattern);
             } else if (gitBranch.matches(hotfixBranchPattern)) {
                 logExecute(GitBranchType.HOTFIX, gitBranch, hotfixBranchPattern);
-            } else if (gitBranch.matches(bugfixBranchPattern)) {
-                logExecute(GitBranchType.BUGFIX, gitBranch, bugfixBranchPattern);
             } else if (gitBranch.matches(developmentBranchPattern)) {
                 logExecute(GitBranchType.DEVELOPMENT, gitBranch, developmentBranchPattern);
             } else {

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/AttachDeployedArtifactsMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/AttachDeployedArtifactsMojo.java
@@ -22,8 +22,7 @@ public class AttachDeployedArtifactsMojo extends AbstractGitflowBasedRepositoryM
                 break;
             }
             case RELEASE:
-            case HOTFIX:
-            case BUGFIX: {
+            case HOTFIX: {
                 getLog().info("Attaching artifacts from stage repository...");
                 attachExistingArtifacts(stageDeploymentRepository, true);
                 break;

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/EnforceVersionsMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/EnforceVersionsMojo.java
@@ -6,7 +6,6 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
-import java.util.EnumSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -17,11 +16,9 @@ import java.util.regex.Pattern;
 @Mojo(name = "enforce-versions", defaultPhase = LifecyclePhase.VALIDATE)
 public class EnforceVersionsMojo extends AbstractGitflowBranchMojo {
 
-    private static EnumSet<GitBranchType> versionedTypes = EnumSet.of(GitBranchType.MASTER, GitBranchType.RELEASE, GitBranchType.HOTFIX, GitBranchType.BUGFIX);
-
     @Override
     protected void execute(final GitBranchType type, final String gitBranch, final String branchPattern) throws MojoExecutionException, MojoFailureException {
-        if (versionedTypes.contains(type)) {
+        if (GitBranchType.VERSIONED_TYPES.contains(type)) {
             getLog().debug("Versioned Branch Type: " + type + " with branchPattern: " + branchPattern + " Checking against current branch: " + gitBranch);
             Matcher gitMatcher = Pattern.compile(branchPattern).matcher(gitBranch);
 

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/GitBranchType.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/GitBranchType.java
@@ -1,5 +1,7 @@
 package com.e_gineering.maven.gitflowhelper;
 
+import java.util.EnumSet;
+
 /**
  * Enum for different types of Git Branches...
  */
@@ -7,8 +9,9 @@ public enum GitBranchType {
     MASTER,
     RELEASE,
     HOTFIX,
-    BUGFIX,
     DEVELOPMENT,
     OTHER,
     UNDEFINED;
+
+    static EnumSet<GitBranchType> VERSIONED_TYPES = EnumSet.of(GitBranchType.MASTER, GitBranchType.RELEASE, GitBranchType.HOTFIX);
 }

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/GitBranchType.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/GitBranchType.java
@@ -13,5 +13,5 @@ public enum GitBranchType {
     OTHER,
     UNDEFINED;
 
-    static EnumSet<GitBranchType> VERSIONED_TYPES = EnumSet.of(GitBranchType.MASTER, GitBranchType.RELEASE, GitBranchType.HOTFIX);
+    static final EnumSet<GitBranchType> VERSIONED_TYPES = EnumSet.of(GitBranchType.MASTER, GitBranchType.RELEASE, GitBranchType.HOTFIX);
 }


### PR DESCRIPTION
Removes the (now) unnecessary and dangerous introduction of branch naming based on branch origination, resolving #24 

This provides a more free-form (less stringent) version assertion, but makes a lot more sense. Also, all version matches and semantics are still enforced for release branches.