### PR TITLE
issue #24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.e-gineering</groupId>
     <artifactId>gitflow-helper-maven-plugin</artifactId>
 
-    <version>1.2.4</version>
+    <version>1.2.5</version>
     <packaging>maven-plugin</packaging>
 
     <name>gitflow-helper-maven-plugin</name>

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/EnforceVersionsMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/EnforceVersionsMojo.java
@@ -35,10 +35,6 @@ public class EnforceVersionsMojo extends AbstractGitflowBranchMojo {
                     }
                 }
             }
-        } else if (!type.equals(GitBranchType.UNDEFINED)) { // Unversioned branch type. Must be -SNAPSHOT.
-            if (!ArtifactUtils.isSnapshot(project.getVersion())) {
-                throw new MojoFailureException("Builds from non-release git branches must end with -SNAPSHOT");
-            }
         }
     }
 }


### PR DESCRIPTION
Failed to remove the assertion in 1.2.4 that required non-release branches to be -SNAPSHOT.