### PR TITLE
Hotfix/1.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.e-gineering</groupId>
     <artifactId>gitflow-helper-maven-plugin</artifactId>
 
-    <version>1.5.0</version>
+    <version>1.5.1</version>
     <packaging>maven-plugin</packaging>
 
     <name>gitflow-helper-maven-plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.aether</groupId>
+            <artifactId>aether-util</artifactId>
+            <version>0.9.0.M2</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.8.2</version>


### PR DESCRIPTION
Resolves issues around artifact promotion when repositories require authentication.

Previously I had been testing the following situation in nexus:

All repositories has anonymous access enabled.
All repositories were writeable by the user specified in the global maven settings.xml.

Whoops.

Anonymous access was a big issue for artifact promotion (the Aether repo for reading artifacts wasn't applying Authentication, but the publishing repo for uploading was).

A huge thanks to @pdziuba for running this to ground and figuring out where the problem was!