### PR TITLE
Issue #52: The Git branch name is now resolved using ScmManager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,21 @@
             <version>3.1.0</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-api</artifactId>
+            <version>1.9.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-manager-plexus</artifactId>
+            <version>1.9.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-gitexe</artifactId>
+            <version>1.9.5</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <version>3.1</version>

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/ScmUtils.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/ScmUtils.java
@@ -1,0 +1,28 @@
+package com.e_gineering.maven.gitflowhelper;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.scm.ScmException;
+import org.apache.maven.scm.ScmFile;
+import org.apache.maven.scm.ScmFileSet;
+import org.apache.maven.scm.log.ScmLogDispatcher;
+import org.apache.maven.scm.manager.ScmManager;
+import org.apache.maven.scm.provider.ScmProvider;
+import org.apache.maven.scm.provider.git.gitexe.command.branch.GitBranchCommand;
+import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
+import org.apache.maven.scm.repository.ScmRepository;
+
+public abstract class ScmUtils {
+    public static String getGitBranch(ScmManager scmManager, MavenProject project) throws ScmException {
+        String scmConnectionUrl = project.getScm().getConnection();
+        String scmDeveloperConnectionUrl = project.getScm().getDeveloperConnection();
+        ScmRepository repository = scmManager.makeScmRepository(StringUtils.isNotBlank(scmDeveloperConnectionUrl) ? scmDeveloperConnectionUrl : scmConnectionUrl);
+        ScmProvider provider = scmManager.getProviderByRepository(repository);
+        if (!GitScmProviderRepository.PROTOCOL_GIT.equals(provider.getScmType())) {
+            return null;
+        } else {
+            ScmFileSet fileSet = new ScmFileSet(project.getBasedir());
+            return GitBranchCommand.getCurrentBranch(new ScmLogDispatcher(), (GitScmProviderRepository)repository.getProviderRepository(), fileSet);
+        }
+    }
+}

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/ScmUtils.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/ScmUtils.java
@@ -16,7 +16,12 @@ public abstract class ScmUtils {
     public static String getGitBranch(ScmManager scmManager, MavenProject project) throws ScmException {
         String scmConnectionUrl = project.getScm().getConnection();
         String scmDeveloperConnectionUrl = project.getScm().getDeveloperConnection();
-        ScmRepository repository = scmManager.makeScmRepository(StringUtils.isNotBlank(scmDeveloperConnectionUrl) ? scmDeveloperConnectionUrl : scmConnectionUrl);
+        String connectionUrl = StringUtils.isNotBlank(scmDeveloperConnectionUrl) ? scmDeveloperConnectionUrl : scmConnectionUrl;
+        if (StringUtils.isBlank(connectionUrl)) {
+            return "${env.GIT_BRANCH}";
+        }
+
+        ScmRepository repository = scmManager.makeScmRepository(connectionUrl);
         ScmProvider provider = scmManager.getProviderByRepository(repository);
         if (!GitScmProviderRepository.PROTOCOL_GIT.equals(provider.getScmType())) {
             return null;


### PR DESCRIPTION
By default the plugin now resolves the name of the current branch using `ScmManager`. This means that '${env.GIT_BRANCH}' is no longer the default value for `gitBranchExpression`, but can still be set explicitly, if necessary.