### PR TITLE
Fix a few unintentional issues after the merge to resolve branches from the current project filelist

### DIFF
--- a/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBranchMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBranchMojo.java
@@ -8,7 +8,6 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.manager.ScmManager;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 
@@ -66,7 +65,7 @@ public abstract class AbstractGitflowBranchMojo extends AbstractMojo {
 
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (gitBranchExpression == null) {
-            gitBranchExpression = getGitBranch();
+            gitBranchExpression = ScmUtils.resolveBranchOrExpression(scmManager, project, getLog());
         }
 
         try {
@@ -103,18 +102,6 @@ public abstract class AbstractGitflowBranchMojo extends AbstractMojo {
             }
         } else {
             logExecute(GitBranchType.UNDEFINED, gitBranch, null);
-        }
-    }
-
-    private String getGitBranch() throws MojoExecutionException {
-        try {
-            String branch = ScmUtils.getGitBranch(scmManager, project);
-            if (branch == null) {
-                throw new MojoExecutionException("gitflow-helper-maven-plugin requires a Git project, use gitBranchExpression to by-pass this check");
-            }
-            return branch;
-        } catch (ScmException e) {
-            throw new MojoExecutionException("Cannot get the branch information from the git repository: \n" + e.getLocalizedMessage(), e);
         }
     }
 }

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/ScmUtils.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/ScmUtils.java
@@ -1,9 +1,9 @@
 package com.e_gineering.maven.gitflowhelper;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.scm.ScmException;
-import org.apache.maven.scm.ScmFile;
 import org.apache.maven.scm.ScmFileSet;
 import org.apache.maven.scm.log.ScmLogDispatcher;
 import org.apache.maven.scm.manager.ScmManager;
@@ -13,21 +13,45 @@ import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
 import org.apache.maven.scm.repository.ScmRepository;
 
 public abstract class ScmUtils {
-    public static String getGitBranch(ScmManager scmManager, MavenProject project) throws ScmException {
-        String scmConnectionUrl = project.getScm().getConnection();
-        String scmDeveloperConnectionUrl = project.getScm().getDeveloperConnection();
-        String connectionUrl = StringUtils.isNotBlank(scmDeveloperConnectionUrl) ? scmDeveloperConnectionUrl : scmConnectionUrl;
-        if (StringUtils.isBlank(connectionUrl)) {
-            return "${env.GIT_BRANCH}";
+    /**
+     * Given the ScmManager for the current execution cycle, and the MavenProject structure, determine if we can
+     * find a maven-provided manner of resolving the current git branch.
+     *
+     * @param scmManager The current maven ScmManager
+     * @param project    The Current maven Project
+     * @param log        A Log to write to
+     * @return The current git branch name, or <code>${env.GIT_BRACH}</code> if the current git branch could not be resolved.
+     * @throws ScmException
+     */
+    public static String resolveBranchOrExpression(final ScmManager scmManager, final MavenProject project, final Log log) {
+        String connectionUrl = null;
+
+        // Some projects don't specify SCM Blocks, and instead rely upon the CI server to provide an '${env.GIT_BRANCH}'
+        if (project.getScm() != null) {
+            // Start with the developer connection, then fall back to the non-developer connection.
+            connectionUrl = project.getScm().getDeveloperConnection();
+            if (StringUtils.isBlank(connectionUrl)) {
+                connectionUrl = project.getScm().getConnection();
+            }
         }
 
-        ScmRepository repository = scmManager.makeScmRepository(connectionUrl);
-        ScmProvider provider = scmManager.getProviderByRepository(repository);
-        if (!GitScmProviderRepository.PROTOCOL_GIT.equals(provider.getScmType())) {
-            return null;
-        } else {
-            ScmFileSet fileSet = new ScmFileSet(project.getBasedir());
-            return GitBranchCommand.getCurrentBranch(new ScmLogDispatcher(), (GitScmProviderRepository)repository.getProviderRepository(), fileSet);
+        if (StringUtils.isNotBlank(connectionUrl)) {
+            try {
+                ScmRepository repository = scmManager.makeScmRepository(connectionUrl);
+                ScmProvider provider = scmManager.getProviderByRepository(repository);
+
+                if (GitScmProviderRepository.PROTOCOL_GIT.equals(provider.getScmType())) {
+                    ScmFileSet fileSet = new ScmFileSet(project.getBasedir());
+                    return GitBranchCommand.getCurrentBranch(new ScmLogDispatcher(), (GitScmProviderRepository) repository.getProviderRepository(), fileSet);
+                } else {
+                    log.warn("Project SCM defines a non-git SCM provider. Falling back to  variable resolution.");
+                }
+            } catch (ScmException se) {
+                log.warn("Unable to resolve Git Branch from Project SCM definition.", se);
+            }
         }
+
+        log.debug("Git branch unresolvable from Project SCM definition, defaulting to ${env.GIT_BRANCH}");
+        return "${env.GIT_BRANCH}";
     }
 }


### PR DESCRIPTION
* NullPointerException when a project doesn't define SCM blocks.
* Centralized the resolution of the git branch name down to the default expression into the single util method without exceptions throwing up the stack.
* Works on multi-module projects that _do_not_ have an SCM block and do not execute the 'tag' step.

@raehalme would you mind taking a look at this PR?