### PR TITLE
Added m2e lifecycle mappings

### DIFF
--- a/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>enforce-versions</goal>
+          <goal>retarget-deploy</goal>
+          <goal>update-stage-dependencies</goal>
+          <goal>set-properties</goal>
+          <goal>tag-master</goal>
+          <goal>promote-master</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>


### PR DESCRIPTION
In order to use a project in eclipse with this plugin, needed to add a lifecycle mapping file so m2e ignores the plugin's goals (not to be used in the IDE).