### PR TITLE
Fix handling of maven aggregator projects with no attachments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,8 @@
     </scm>
 
     <properties>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/DefaultGavCoordinateHelper.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/DefaultGavCoordinateHelper.java
@@ -2,8 +2,8 @@ package com.e_gineering.maven.gitflowhelper;
 
 import com.google.common.base.Joiner;
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.logging.Logger;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.resolution.ArtifactResult;
 
@@ -15,47 +15,36 @@ import static com.google.common.base.Strings.emptyToNull;
 /**
  * A helper factory for creating maven (GroupId, ArtifactId, Extension, Classifier, Version) coordinates.
  */
-class GavCoordinateFactory {
-    // TODO(somebody): Consider using maven @Component to make this an injectable component in the mojo
+class DefaultGavCoordinateHelper implements GavCoordinateHelper {
 
     private static final Joiner GAV_JOINER = Joiner.on(':').skipNulls();
 
-    private final RepositorySystemSession session;
+    private final Logger log;
 
     private final MavenProject project;
-    private final Log log;
+
+    private final RepositorySystemSession session;
 
     /**
-     * Creates a new {@link GavCoordinateFactory}.
+     * Creates a new {@link DefaultGavCoordinateHelperFactory}.
      *
      * @param session the repository session
      * @param project the project
      * @param log     the logger
      */
-    GavCoordinateFactory(RepositorySystemSession session, MavenProject project, Log log) {
+    DefaultGavCoordinateHelper(RepositorySystemSession session, MavenProject project, Logger log) {
         this.session = checkNotNull(session, "session must not be null");
         this.project = checkNotNull(project, "project must not be null");
         this.log = checkNotNull(log, "log must not be null");
     }
 
-    /**
-     * Get GAV coordinates for the {@link ArtifactResult}.
-     *
-     * @param result the result
-     * @return the GAV coordinate string
-     */
-    String getCoordinates(ArtifactResult result) {
+    @Override
+    public String getCoordinates(ArtifactResult result) {
         return getCoordinates(result.getArtifact());
     }
 
-    /**
-     * Get GAV coordinates for the {@link org.eclipse.aether.artifact.Artifact}.
-     *
-     * @param artifact the artifact
-     * @return the GAV coordinate string
-     */
-    @SuppressWarnings("WeakerAccess")
-    String getCoordinates(org.eclipse.aether.artifact.Artifact artifact) {
+    @Override
+    public String getCoordinates(org.eclipse.aether.artifact.Artifact artifact) {
         return getCoordinates(
                 emptyToNull(artifact.getGroupId()),
                 emptyToNull(artifact.getArtifactId()),
@@ -65,13 +54,8 @@ class GavCoordinateFactory {
         );
     }
 
-    /**
-     * Get GAV coordinates for the {@link Artifact}.
-     *
-     * @param artifact the artifact
-     * @return the GAV coordinate string
-     */
-    String getCoordinates(Artifact artifact) {
+    @Override
+    public String getCoordinates(Artifact artifact) {
         log.debug("   Encoding Coordinates For: " + artifact);
 
         // Get the extension according to the artifact type.

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/DefaultGavCoordinateHelperFactory.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/DefaultGavCoordinateHelperFactory.java
@@ -1,0 +1,25 @@
+package com.e_gineering.maven.gitflowhelper;
+
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.logging.Logger;
+import org.eclipse.aether.RepositorySystemSession;
+
+/**
+ * A helper factory for creating {@link GavCoordinateHelper} instances scoped to a repository session.
+ */
+@Component(role = GavCoordinateHelperFactory.class)
+class DefaultGavCoordinateHelperFactory implements GavCoordinateHelperFactory {
+
+    @Requirement
+    private Logger log;
+
+    @Requirement
+    private MavenProject project;
+
+    @Override
+    public GavCoordinateHelper using(RepositorySystemSession session) {
+        return new DefaultGavCoordinateHelper(session, project, log);
+    }
+}

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/GavCoordinateFactory.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/GavCoordinateFactory.java
@@ -1,0 +1,113 @@
+package com.e_gineering.maven.gitflowhelper;
+
+import com.google.common.base.Joiner;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.resolution.ArtifactResult;
+
+import javax.annotation.Nullable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.emptyToNull;
+
+/**
+ * A helper factory for creating maven (GroupId, ArtifactId, Extension, Classifier, Version) coordinates.
+ */
+class GavCoordinateFactory {
+    // TODO(somebody): Consider using maven @Component to make this an injectable component in the mojo
+
+    private static final Joiner GAV_JOINER = Joiner.on(':').skipNulls();
+
+    private final RepositorySystemSession session;
+
+    private final MavenProject project;
+    private final Log log;
+
+    /**
+     * Creates a new {@link GavCoordinateFactory}.
+     *
+     * @param session the repository session
+     * @param project the project
+     * @param log     the logger
+     */
+    GavCoordinateFactory(RepositorySystemSession session, MavenProject project, Log log) {
+        this.session = checkNotNull(session, "session must not be null");
+        this.project = checkNotNull(project, "project must not be null");
+        this.log = checkNotNull(log, "log must not be null");
+    }
+
+    /**
+     * Get GAV coordinates for the {@link ArtifactResult}.
+     *
+     * @param result the result
+     * @return the GAV coordinate string
+     */
+    String getCoordinates(ArtifactResult result) {
+        return getCoordinates(result.getArtifact());
+    }
+
+    /**
+     * Get GAV coordinates for the {@link org.eclipse.aether.artifact.Artifact}.
+     *
+     * @param artifact the artifact
+     * @return the GAV coordinate string
+     */
+    @SuppressWarnings("WeakerAccess")
+    String getCoordinates(org.eclipse.aether.artifact.Artifact artifact) {
+        return getCoordinates(
+                emptyToNull(artifact.getGroupId()),
+                emptyToNull(artifact.getArtifactId()),
+                emptyToNull(artifact.getBaseVersion()),
+                emptyToNull(artifact.getExtension()),
+                emptyToNull(artifact.getClassifier())
+        );
+    }
+
+    /**
+     * Get GAV coordinates for the {@link Artifact}.
+     *
+     * @param artifact the artifact
+     * @return the GAV coordinate string
+     */
+    String getCoordinates(Artifact artifact) {
+        log.debug("   Encoding Coordinates For: " + artifact);
+
+        // Get the extension according to the artifact type.
+        String extension = session.getArtifactTypeRegistry().get(artifact.getType()).getExtension();
+
+        // assert that the file extension matches the artifact packaging extension type, if there is an artifact file.
+        if (artifact.getFile() != null && !artifact.getFile().getName().toLowerCase().endsWith(extension.toLowerCase())) {
+            String filename = artifact.getFile().getName();
+            String fileExtension = filename.substring(filename.lastIndexOf('.') + 1);
+            log.warn(
+                    "    Artifact file name: " + artifact.getFile().getName() + " of type "
+                            + artifact.getType() + " does not match the extension for the ArtifactType: "
+                            + extension + ". "
+                            + "This is likely an issue with the packaging definition for '" + artifact.getType()
+                            + "' artifacts, which may be missing an extension definition. "
+                            + "The gitflow helper catalog will use the actual file extension: " + fileExtension
+            );
+            extension = fileExtension;
+        }
+
+        return getCoordinates(
+                artifact.getGroupId(),
+                artifact.getArtifactId(),
+                project.getVersion(),
+                extension, artifact.hasClassifier() ? artifact.getClassifier() : null
+        );
+    }
+
+    private String getCoordinates(String groupId,
+                                  String artifactId,
+                                  String version,
+                                  @Nullable String extension,
+                                  @Nullable String classifier) {
+        checkNotNull(groupId, "groupId must not be null");
+        checkNotNull(artifactId, "artifactId must not be null");
+        checkNotNull(version, "version must not be null");
+        return GAV_JOINER.join(groupId, artifactId, extension, classifier, version);
+    }
+}

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/GavCoordinateHelper.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/GavCoordinateHelper.java
@@ -1,0 +1,33 @@
+package com.e_gineering.maven.gitflowhelper;
+
+import org.apache.maven.artifact.Artifact;
+import org.eclipse.aether.resolution.ArtifactResult;
+
+/**
+ * A helper factory for creating maven (GroupId, ArtifactId, Extension, Classifier, Version) coordinates.
+ */
+public interface GavCoordinateHelper {
+    /**
+     * Get GAV coordinates for the {@link ArtifactResult}.
+     *
+     * @param result the result
+     * @return the GAV coordinate string
+     */
+    String getCoordinates(ArtifactResult result);
+
+    /**
+     * Get GAV coordinates for the {@link org.eclipse.aether.artifact.Artifact}.
+     *
+     * @param artifact the artifact
+     * @return the GAV coordinate string
+     */
+    String getCoordinates(org.eclipse.aether.artifact.Artifact artifact);
+
+    /**
+     * Get GAV coordinates for the {@link Artifact}.
+     *
+     * @param artifact the artifact
+     * @return the GAV coordinate string
+     */
+    String getCoordinates(Artifact artifact);
+}

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/GavCoordinateHelperFactory.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/GavCoordinateHelperFactory.java
@@ -1,0 +1,19 @@
+package com.e_gineering.maven.gitflowhelper;
+
+import org.eclipse.aether.RepositorySystemSession;
+
+/**
+ * A {@link GavCoordinateHelper} factory.
+ */
+public interface GavCoordinateHelperFactory {
+
+    String ROLE = GavCoordinateHelperFactory.class.getName();
+
+    /**
+     * Create a coordinate helper scoped to the {@link RepositorySystemSession}.
+     *
+     * @param session the session
+     * @return the coordinate helper
+     */
+    GavCoordinateHelper using(RepositorySystemSession session);
+}


### PR DESCRIPTION
Updates AbstractGitFlowBasedRepositoryMojo to Fix #44
Updates pom.xml to add expected code level (inferred from usage of `Files.createTempDirectory` which is `@since 1.7`)
Updates AbstractGitFlowBasedRepositoryMojo to 1.7 compatibility

Pertaining to #44:

When a pom type artifact is processed, whilst the project artifact has a value it does not have a file and therefore the main artifact is not added to the catalog, this is correct behaviour. However since neither the primary artifact nor the attached artifacts contribute any entries to the catalog this results in an empty file being sent to the repository. Certain repositories, I have tested under nexus 1.9.1, do not allow empty artifacts to be uploaded and therefore this results in an error when processing the promote-master mojo.

This can be resolved by adding a section header to the catalog such that it is of the form:

```
[artifacts]
group:artifact:extension:classifier-1:version
group:artifact:extension:classifier-2:version
```

with this the empty version becomes

```
[artifacts]
```

and thus behaves as expected