### PR TITLE
Restore behavior from 1.7.x for OTHER branch types

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ All of the solutions to these issues are implemented independently in different 
                             <hotfixBranchPropertyFile>foo/bar/emer.props</hotfixBranchPropertyFile>
                             <releaseBranchPropertyFile>foo/bar/test.props</releaseBranchPropertyFile>
                             <developmentBranchPropertyFile>foo/bar/dev.props</developmentBranchPropertyFile>
-                            <featureOrBugfixBranchPropertyFile>foo/bar/feat.props</featureOrBugfixBranchPropertyFile>
                             <otherBranchPropertyFile>foo/bar/ci.props</otherBranchPropertyFile>
                             <undefinedBranchPropertyFile>foo/bar/local.props</undefinedBranchPropertyFile>
                         </configuration>
@@ -144,9 +143,9 @@ One common stumbling block for teams adjusting to gitflow with Maven projects is
 In practice, the Maven versions should:
  
  * Be synchronized with release branch and hotfix branch names.
- * Never be -SNAPSHOT in the master, support, release, or hotfix branches. Also, no -SNAPSHOT parent or (plugin) dependencies are allowed. (This condition may be disabled by setting `enforceNonSnapshots` = `false`.)
- * Always be -SNAPSHOT in the feature and develop branches.
- * Be irrelevant if there's no git branch resolvable from your environment.
+ * Never be -SNAPSHOT in the master, support, release, or hotfix branches. Also, no -SNAPSHOT parent or (plugin) dependencies are allowed.
+ * Always be -SNAPSHOT in the develop branch.
+ * Be irrelevant if there's no git branch resolvable from your environment or working in a branch which is not deployed to remote repositories.
 
 The `enforce-versions` goal asserts these semantics when it can resolve the `gitBranchExpression`.
 
@@ -166,7 +165,6 @@ The following properties change the behavior of this goal:
 | supportBranchPattern | (origin/)?support/(.*) | No | Regex. When matches, signals a support branch (long term master-equivalent for older release) being built. Last subgroup, if present, must be start of the Maven project version. |
 | releaseBranchPattern | (origin/)?release/(.*) | No | Regex. When matched, signals a release branch being built. Last subgroup, if present, must match the Maven project version. |
 | hotfixBranchPattern  | (origin/)?hotfix/(.*) | No | Regex. When matched, signals a hotfix branch is being built. Last subgroup, if present, must match the Maven project version. |
-| featureOrBugfixBranchPattern | (origin/)?(?:feature&#124;bugfix)/(.*) | Yes | Regex. When matched, signals a feature or bugfix branch is being built. |
 | developmentBranchPattern | (origin/)?develop | Yes | Regex. When matched, signals a development branch is being built. Note the lack of a subgroup. |
 
 
@@ -185,7 +183,6 @@ plugins in the build process (deploy, site-deploy, etc.) will use the repositori
 | Property | Default Value | Description | 
 | -------- | ------------- | ----------- |
 | gitBranchExpression  | current git branch resolved from SCM or ${env.GIT_BRANCH} | Maven property expression to resolve in order to determine the current git branch |
-| deploySnapshotTypeBranches  | `false` | When `true`, feature branches will also be deployed to the snapshots repository. |
 | releaseDeploymentRepository | n/a | The repository to use for releases. (Builds with a GIT_BRANCH matching `masterBranchPattern` or `supportBranchPattern`) |
 | stageDeploymentRepository | n/a | The repository to use for staging. (Builds with a GIT_BRANCH matching `releaseBranchPattern` or `hotfixBranchPattern`) | 
 | snapshotDeploymentRepository | n/a | The repository to use for snapshots. (Builds matching `developmentBranchPattern`) |
@@ -339,7 +336,6 @@ The following table describes the git branch expression -> repository used for r
 | supportBranchPattern  | release    |
 | releaseBranchPattern  | stage      |
 | hotfixBranchPattern   | stage      |
-| featureOrBugfixBranchPattern | snapshots | 
 | developmentBranchPattern | snapshots | 
 | All Others            | local      |
  
@@ -360,7 +356,6 @@ The second job would have a clean workspace, with the proper version of the proj
 it's building. The attach-deploy will 'clean' the maven project, then download the binary artifacts from the repository
 that the first build deployed into. Once they're attached to the project, the `jboss-as:deploy-only` goal will deliver
 the artifacts built by the first job into a jboss application server.
-
 
 # Resolving the Git branch name
 As stated before, the plugin determines what to do by resolving the Git branch name.

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBasedRepositoryMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBasedRepositoryMojo.java
@@ -25,7 +25,15 @@ import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.util.repository.AuthenticationBuilder;
 
 import javax.annotation.Nullable;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBranchMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBranchMojo.java
@@ -1,6 +1,5 @@
 package com.e_gineering.maven.gitflowhelper;
 
-import com.e_gineering.maven.gitflowhelper.properties.ExpansionBuffer;
 import com.e_gineering.maven.gitflowhelper.properties.PropertyResolver;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -42,18 +41,16 @@ public abstract class AbstractGitflowBranchMojo extends AbstractMojo {
     @Parameter(defaultValue = "(origin/)?develop", property = "developmentBranchPattern", required = true)
     private String developmentBranchPattern;
 
-    @Parameter(defaultValue = "(origin/)?(?:feature|bugfix)/(.*)", property = "featureOrBugfixBranchPattern", required = true)
-    private String featureOrBugfixBranchPattern;
-
     // An expression that resolves to the git branch at run-time.
     // @Parameter tag causes property resolution to fail for patterns containing ${env.}.
     // The default value _must_ be provided programmaticially at run-time.
     @Parameter(property = "gitBranchExpression", required = false)
     private String gitBranchExpression;
 
-    @Parameter(defaultValue = "false", property = "deploySnapshotTypeBranches")
-    boolean deploySnapshotTypeBranches;
-
+    /**
+     * If this is "equals" then exact version matching to branch name matching is preformed.
+     * Otherwise, this is treated as a "startsWith".
+     */
     @Parameter(defaultValue = "equals", property = "releaseBranchMatchType", required = true)
     String releaseBranchMatchType;
 
@@ -88,7 +85,7 @@ public abstract class AbstractGitflowBranchMojo extends AbstractMojo {
         // Validate the match type.
         checkReleaseBranchMatchTypeParam();
 
-        ScmUtils scmUtils = new ScmUtils(systemEnvVars, scmManager, project, getLog(), masterBranchPattern, supportBranchPattern, releaseBranchPattern, hotfixBranchPattern, developmentBranchPattern, featureOrBugfixBranchPattern);
+        ScmUtils scmUtils = new ScmUtils(systemEnvVars, scmManager, project, getLog(), masterBranchPattern, supportBranchPattern, releaseBranchPattern, hotfixBranchPattern, developmentBranchPattern);
         GitBranchInfo branchInfo = scmUtils.resolveBranchInfo(gitBranchExpression);
 
         getLog().debug("Building for: " + branchInfo);

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/AttachDeployedArtifactsMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/AttachDeployedArtifactsMojo.java
@@ -29,7 +29,6 @@ public class AttachDeployedArtifactsMojo extends AbstractGitflowBasedRepositoryM
                 attachExistingArtifacts(stageDeploymentRepository, true);
                 break;
             }
-            case FEATURE_OR_BUGFIX_BRANCH:
             case DEVELOPMENT: {
                 getLog().info("Attaching artifacts from snapshot repository...");
                 attachExistingArtifacts(snapshotDeploymentRepository, true);

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/EnforceVersionsMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/EnforceVersionsMojo.java
@@ -44,27 +44,6 @@ public class EnforceVersionsMojo extends AbstractGitflowBranchMojo {
             }
         } else if (GitBranchType.SNAPSHOT_TYPES.contains(branchInfo.getType()) && !ArtifactUtils.isSnapshot(project.getVersion())) {
             throw new MojoFailureException("The current git branch: [" + branchInfo.getName() + "] is detected as a SNAPSHOT-type branch, and expects a maven project version ending with -SNAPSHOT. The maven project version found was: [" + project.getVersion() + "]");
-        } else if (GitBranchType.FEATURE_OR_BUGFIX_BRANCH.equals(branchInfo.getType()) && deploySnapshotTypeBranches) {
-            checkFeatureOrBugfixBranchVersion(branchInfo);
-        }
-    }
-
-    private void checkFeatureOrBugfixBranchVersion(final GitBranchInfo branchInfo) throws MojoFailureException {
-        // For FEATURE and BUGFIX branches, check if the POM version includes the branch name
-        Matcher gitMatcher = Pattern.compile(branchInfo.getPattern()).matcher(branchInfo.getName());
-        if (gitMatcher.matches()) {
-            String branchName = gitMatcher.group(gitMatcher.groupCount());
-            String v = project.getVersion();
-            String branchNameSnapshot = branchName + "-" + Artifact.SNAPSHOT_VERSION;
-            if (v.length() < branchNameSnapshot.length() || !v.regionMatches(
-                    true,
-                    v.length() - branchNameSnapshot.length(),
-                    branchNameSnapshot,
-                    0,
-                    branchNameSnapshot.length())
-                    ) {
-                throw new MojoFailureException("The project's version should end with [" + branchNameSnapshot + "]");
-            }
         }
     }
 

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/GitBranchType.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/GitBranchType.java
@@ -11,11 +11,10 @@ public enum GitBranchType {
     RELEASE,
     HOTFIX,
     DEVELOPMENT,
-    FEATURE_OR_BUGFIX_BRANCH,
     OTHER,
     UNDEFINED;
 
     static final EnumSet<GitBranchType> VERSIONED_TYPES = EnumSet.of(MASTER, SUPPORT, RELEASE, HOTFIX);
-    static final EnumSet<GitBranchType> SNAPSHOT_TYPES = EnumSet.of(DEVELOPMENT, FEATURE_OR_BUGFIX_BRANCH, OTHER);
+    static final EnumSet<GitBranchType> SNAPSHOT_TYPES = EnumSet.of(DEVELOPMENT);
     static final EnumSet<GitBranchType> UNIQUELY_VERSIONED_TYPES = EnumSet.of(SUPPORT, RELEASE, HOTFIX);
 }

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/MasterPromoteExtension.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/MasterPromoteExtension.java
@@ -1,6 +1,5 @@
 package com.e_gineering.maven.gitflowhelper;
 
-import com.e_gineering.maven.gitflowhelper.properties.PropertyResolver;
 import org.apache.maven.AbstractMavenLifecycleParticipant;
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.execution.MavenSession;
@@ -15,7 +14,6 @@ import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -168,7 +166,7 @@ public class MasterPromoteExtension extends AbstractMavenLifecycleParticipant {
             }
             logger.debug("Feature or Bugfix Branch Pattern: " + featureOrBugfixBranchPattern);
 
-            ScmUtils scmUtils = new ScmUtils(systemEnvVars, scmManager, session.getTopLevelProject(), new PlexusLoggerToMavenLog(logger), masterBranchPattern, supportBranchPattern, releaseBranchPattern, hotfixBranchPattern, developmentBranchPattern, featureOrBugfixBranchPattern);
+            ScmUtils scmUtils = new ScmUtils(systemEnvVars, scmManager, session.getTopLevelProject(), new PlexusLoggerToMavenLog(logger), masterBranchPattern, supportBranchPattern, releaseBranchPattern, hotfixBranchPattern, developmentBranchPattern);
             GitBranchInfo branchInfo = scmUtils.resolveBranchInfo(gitBranchExpression);
 
             //GitBranchInfo branchInfo = ScmUtils.getGitBranchInfo(scmManager, session.getTopLevelProject(), new PlexusLoggerToMavenLog(logger), gitBranchExpression, masterBranchPattern, supportBranchPattern, releaseBranchPattern, hotfixBranchPattern, developmentBranchPattern, featureOrBugfixBranchPattern);

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/PromoteMasterMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/PromoteMasterMojo.java
@@ -20,11 +20,10 @@ public class PromoteMasterMojo extends AbstractGitflowBasedRepositoryMojo {
     @Override
     protected void execute(final GitBranchInfo gitBranchInfo) throws MojoExecutionException, MojoFailureException {
         switch (gitBranchInfo.getType()) {
-            case FEATURE_OR_BUGFIX_BRANCH:
             case DEVELOPMENT:
             case HOTFIX:
             case RELEASE: {
-                // In order to use promote-master or attach-deployed, we need to build an artifactCatalog on deliverable branches.
+                // In order to use promote-master or attach-deployed, we need to build an artifactCatalog on deployable branches.
                 attachArtifactCatalog();
                 break;
             }

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/RetargetDeployMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/RetargetDeployMojo.java
@@ -43,16 +43,6 @@ public class RetargetDeployMojo extends AbstractGitflowBasedRepositoryMojo {
                 project.setReleaseArtifactRepository(null);
                 break;
             }
-            case FEATURE_OR_BUGFIX_BRANCH: {
-                if (deploySnapshotTypeBranches) {
-                    getLog().info("Setting snapshot artifact repository to: [" + snapshotDeploymentRepository + "]");
-                    project.setSnapshotArtifactRepository(getDeploymentRepository(snapshotDeploymentRepository));
-                    project.setReleaseArtifactRepository(null);
-                } else {
-                    unsetRepos();
-                }
-                break;
-            }
             default: {
                 unsetRepos();
                 break;

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/ScmUtils.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/ScmUtils.java
@@ -3,7 +3,6 @@ package com.e_gineering.maven.gitflowhelper;
 import com.e_gineering.maven.gitflowhelper.properties.ExpansionBuffer;
 import com.e_gineering.maven.gitflowhelper.properties.PropertyResolver;
 import org.apache.commons.lang.StringUtils;
-import org.apache.maven.MavenExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.scm.ScmException;
@@ -20,7 +19,6 @@ import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.codehaus.plexus.util.cli.Commandline;
 import org.codehaus.plexus.util.cli.StreamConsumer;
 
-import java.io.IOException;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
@@ -45,7 +43,7 @@ class ScmUtils {
 
     public ScmUtils(final Properties systemEnvVars, final ScmManager scmManager, final MavenProject project, final Log log,
                     final String masterBranchPattern, final String supportBranchPattern, final String releaseBranchPattern,
-                    final String hotfixBranchPattern, final String developmentBranchPattern, final String featureOrBugfixBranchPattern)
+                    final String hotfixBranchPattern, final String developmentBranchPattern)
     {
         this.systemEnvVars = systemEnvVars;
         this.scmManager = scmManager;
@@ -199,8 +197,6 @@ class ScmUtils {
             return new GitBranchInfo(branchName, GitBranchType.HOTFIX, hotfixBranchPattern);
         } else if (branchName.matches(developmentBranchPattern)) {
             return new GitBranchInfo(branchName, GitBranchType.DEVELOPMENT, developmentBranchPattern);
-        } else if (branchName.matches(featureOrBugfixBranchPattern)) {
-            return new GitBranchInfo(branchName, GitBranchType.FEATURE_OR_BUGFIX_BRANCH, featureOrBugfixBranchPattern);
         } else {
             return new GitBranchInfo(branchName, GitBranchType.OTHER, null);
         }

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/SetPropertiesMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/SetPropertiesMojo.java
@@ -79,18 +79,6 @@ public class SetPropertiesMojo extends AbstractGitflowBranchMojo {
     private File developmentBranchPropertyFile;
 
     /**
-     * Properties to be applied if executing against the development branch
-     */
-    @Parameter(property = "featureOrBugfixBranchProperties")
-    private Properties featureOrBugfixBranchProperties;
-
-    /**
-     * A Property file to load if executing against the feature or bugfix branch
-     */
-    @Parameter(property = "featureOrBugfixBranchPropertyFile")
-    private File featureOrBugfixBranchPropertyFile;
-
-    /**
      * Properties to be applied if executing against a non-releasable branch
      */
     @Parameter(property = "otherBranchProperties")
@@ -161,11 +149,6 @@ public class SetPropertiesMojo extends AbstractGitflowBranchMojo {
             case DEVELOPMENT: {
                 toInject = developmentBranchProperties;
                 toLoad = developmentBranchPropertyFile;
-                break;
-            }
-            case FEATURE_OR_BUGFIX_BRANCH: {
-                toInject = featureOrBugfixBranchProperties;
-                toLoad = featureOrBugfixBranchPropertyFile;
                 break;
             }
             case OTHER: {


### PR DESCRIPTION
Removes / rolls back all changes in 1.8.0 that related to the FEATURE_OR_BUGFIX_BRANCH.

This will restore the existing workflows for version management for projects using releases <= 1.7.x.

While I recognize the intent of these changes, the manner in which it was implemented breaks existing workflows for CI builds and version checks in several environments I've been involved in.
The inability to merge a feature or bugfix branch into a release branch (without mangling the version in the pom.xml) after the merge or without a merge conflict is a sticking point.

As discussed in #87, there are longer-term changes that we should make to account for the desire to publish OTHER types of branches into a repository. Those changes will be addressed in a different body of work.