### PR TITLE
Feature/deploy others semver

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ plugins in the build process (deploy, site-deploy, etc.) will use the repositori
 | releaseDeploymentRepository | n/a | The repository to use for releases. (Builds with a GIT_BRANCH matching `masterBranchPattern` or `supportBranchPattern`) |
 | stageDeploymentRepository | n/a | The repository to use for staging. (Builds with a GIT_BRANCH matching `releaseBranchPattern` or `hotfixBranchPattern`) | 
 | snapshotDeploymentRepository | n/a | The repository to use for snapshots. (Builds matching `developmentBranchPattern`) |
-| otherDeploymentBranchPattern | false | N/A | Regex. When matched, the branch name is normalized and any artifacts produced by the build will include the normalized branch name and -SNAPSHOT. Deployment will target the snapshot repository|
+| otherDeploymentBranchPattern | n/a | Regex. When matched, the branch name is normalized and any artifacts produced by the build will include the normalized branch name and -SNAPSHOT. Deployment will target the snapshot repository |
 
 **The repository properties should follow the following format**, `id::layout::url::uniqueVersion`.
 

--- a/README.md
+++ b/README.md
@@ -371,8 +371,22 @@ the artifacts built by the first job into a jboss application server.
     * If the detached HEAD commit resolves to a single branch type, it uses that branch name.
 3. If the first two methods fail, the plugin attempts to resolve `${env.GIT_BRANCH}`.
 
+## To Debug the plugin (replicating a test-case but without being run from jUnit)
+You can 'bootstrap' the plugin into your local repository and get the test project stubbed by running:
+`mvn -Dmaven.test.skip=true install` 
+
+Then, change directories:
+`cd target/test-classes/project-stub`
+
+From there, you'll need to supply the required environment variables or commandline arguments to `mvnDebug`:
+```
+export GIT_BRANCH=origin/feature/mybranch-foo-bar
+mvnDebug -Dstub.project.version=5.0.0-SNAPSHOT -DotherBranchDeploy=semver -DallowGitflowPluginSnapshot=true  deploy
+```
+You can then connect a remote debugger and step through the plugin code.
+
 ## Building with IntelliJ IDEA notes
-### To Debug Tests:
+### To Debug Test Code:
 Configure the Maven commandline to include
 `-DforkMode=never` You will likely get warnings when you run maven with this argument.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It does so by:
     * SCM tagging builds for master and support branches. You can use the project SCM definition, or if you omit it, you can resolve the CI server's repository connection information. (Zero Maven scm configuration necessary)
     * Promoting existing tested (staged) artifacts for release, rather than re-building the artifacts. Eliminates the risk of accidental master merges or commits resulting in untested code being released, and provides digest hash traceability for the history of artifacts.
     * Enabling the decoupling of repository deployment and execution environment delivery based on the current git branch.
+    * Allowing for long-running non-release branches to be deployed to snapshots, automatically reversioning the artifacts based off the branch name.
  * Automated deployment, promotion, and delivery of projects without the [maven-release-plugin](http://maven.apache.org/maven-release/maven-release-plugin/) or some other [*almost there* solution](https://axelfontaine.com/blog/final-nail.html).
  * Customizing maven project and system properties based upon the current branch being built. This allows test cases to target different execution environments without changing the artifact results.
  * Enabling automatic purging and resolving (force update) of 'release' and 'hotfix' release versioned dependencies resolved from the 'stage' repository.
@@ -24,6 +25,7 @@ This plugin solves a few specific issues common in consolidated Hudson/Jenkins C
  4. Set arbitrary project properties based upon the type of GIT branch being built. 
  5. Reliably tag deploy builds from the master and support branches
  6. Enable split 'deploy' vs. 'deliver' maven CI job configuration, without rebuilding artifacts for the 'deliver' phase.
+ 7. Allow for deployment of long-running feature branches to repositories without having to mangle the version in the pom.xml.
  
 In addition to supporting these goals for the project, this plugin does it in a manner that tries to be as effortless (yet configurable) as possible.
 If you use non-standard gitflow branch names (emer instead of hotfix), this plugin supports that. If you don't want to do version enforcement, this plugin supports that. 
@@ -107,14 +109,16 @@ All of the solutions to these issues are implemented independently in different 
                     <releaseDeploymentRepository>localnexus-releases</releaseDeploymentRepository>
                     <stageDeploymentRepository>localnexus-stage</stageDeploymentRepository>
                     <snapshotDeploymentRepository>localnexus-snapshots</snapshotDeploymentRepository>
+                    <!-- Allow branches starting with feature/poc to be published as automagically versioned branch-name-SNAPSHOT artifacts -->
+                    <otherDeploymentBranchPattern>(origin/)feature/poc/.*</otherDeploymentBranchPattern>
                 </configuration>
                 <executions>
                     <execution>
                         <goals>
                             <goal>enforce-versions</goal>
+                            <goal>set-properties</goal>
                             <goal>retarget-deploy</goal>
                             <goal>update-stage-dependencies</goal>
-                            <goal>set-properties</goal>
                             <goal>tag-master</goal>
                             <goal>promote-master</goal>
                         </goals>
@@ -167,6 +171,19 @@ The following properties change the behavior of this goal:
 | hotfixBranchPattern  | (origin/)?hotfix/(.*) | No | Regex. When matched, signals a hotfix branch is being built. Last subgroup, if present, must match the Maven project version. |
 | developmentBranchPattern | (origin/)?develop | Yes | Regex. When matched, signals a development branch is being built. Note the lack of a subgroup. |
 
+## Goal: `set-properties` (Dynamically Set Maven Project / System Properties)
+
+Some situations with automated testing (and integration testing in particular) demand changing configuration properties 
+based upon the branch type being built. This is a common necessity when configuring automated DB refactorings as part of
+a build, or needing to setup / configure datasources for automated tests to run against.
+
+The `set-properties` goal allows for setting project (or system) properties, dynamically based on the detected git
+branch being built. Properties can be specified as a Properties collection in plugin configuration, or can be loaded
+from a property file during the build. Both property key names and property values will have placeholders resolved.
+
+Multiple executions can be configured, and each execution can target different scopes (system or project), and can load
+properties from files with an assigned keyPrefix, letting you name-space properties from execution ids.
+
 
 ## Goal: `retarget-deploy` (Branch Specific Deploy Targets & Staging)
 
@@ -186,7 +203,7 @@ plugins in the build process (deploy, site-deploy, etc.) will use the repositori
 | releaseDeploymentRepository | n/a | The repository to use for releases. (Builds with a GIT_BRANCH matching `masterBranchPattern` or `supportBranchPattern`) |
 | stageDeploymentRepository | n/a | The repository to use for staging. (Builds with a GIT_BRANCH matching `releaseBranchPattern` or `hotfixBranchPattern`) | 
 | snapshotDeploymentRepository | n/a | The repository to use for snapshots. (Builds matching `developmentBranchPattern`) |
-
+| otherDeploymentBranchPattern | false | N/A | Regex. When matched, the branch name is normalized and any artifacts produced by the build will include the normalized branch name and -SNAPSHOT. Deployment will target the snapshot repository|
 
 **The repository properties should follow the following format**, `id::layout::url::uniqueVersion`.
 
@@ -235,20 +252,15 @@ Can be replaced with the following plugin configuration, which also introduces t
         ...
     </build>
 
+### Deploying non-release (OTHER) type branches as -SNAPSHOT releases.
 
-## Goal: `set-properties` (Dynamically Set Maven Project / System Properties)
-
-Some situations with automated testing (and integration testing in particular) demand changing configuration properties 
-based upon the branch type being built. This is a common necessity when configuring automated DB refactorings as part of
-a build, or needing to setup / configure datasources for automated tests to run against.
-
-The `set-properties` goal allows for setting project (or system) properties, dynamically based on the detected git
-branch being built. Properties can be specified as a Properties collection in plugin configuration, or can be loaded
-from a property file during the build. Both property key names and property values will have placeholders resolved.
-
-Multiple executions can be configured, and each execution can target different scopes (system or project), and can load
-properties from files with an assigned keyPrefix, letting you name-space properties from execution ids.
-
+In addition to setting up repository targets for release branches, the `retarget-depoy` branch can deploy other branches
+matching the `otherDeploymentBranchPattern` as -SNAPSHOT artifacts which include the branch name as build metadata.
+This is loosely based on the [semVer](https://semver.org) semantic version scheme, in that the plugin will reversion any
+artifacts to be produced with `+feature-branch-name-normalized-SNAPSHOT` where any characters not in `[0-9A-Za-z-.]` will
+be replaced with `-`. Artifact versions for feature branches will _always_ be -SNAPSHOT, and will _always_ target the 
+Snapshots repository. The intent for this configuration setting is to provide a way for long-running branches (matching 
+a naming convention you define) can be published to a SNAPSHOT repo for use by other projects.
 
 ## Goal: `update-stage-dependencies` (Force update of dependency staged Releases)
 

--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ The following table describes the git branch expression -> repository used for r
 | releaseBranchPattern  | stage      |
 | hotfixBranchPattern   | stage      |
 | developmentBranchPattern | snapshots | 
+| otherBranchesToDeploy | snapshots | 
 | All Others            | local      |
  
 As an example, assume you have two CI jobs. 
@@ -400,7 +401,7 @@ You can then connect a remote debugger and step through the plugin code.
 ## Building with IntelliJ IDEA notes
 ### To Debug Test Code:
 Configure the Maven commandline to include
-`-DforkMode=never` You will likely get warnings when you run maven without this argument.
+`-DforkMode=never` You will likely get warnings when you run maven with this argument.
 
 ### To inspect code-coverage results from Integration Tests:
 * Select the **Analyze** -> **Show Coverage Data** menu.

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBasedRepositoryMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBasedRepositoryMojo.java
@@ -84,6 +84,9 @@ abstract class AbstractGitflowBasedRepositoryMojo extends AbstractGitflowBranchM
     @Parameter(defaultValue = "${repositorySystemSession}", required = true)
     RepositorySystemSession session;
 
+    @Parameter(property = "gitflow.force.other.deploy", defaultValue = "false", required = true)
+    String forceOtherDeploy;
+
     @Component
     private EnhancedLocalRepositoryManagerFactory localRepositoryManagerFactory;
 

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBasedRepositoryMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBasedRepositoryMojo.java
@@ -84,8 +84,8 @@ abstract class AbstractGitflowBasedRepositoryMojo extends AbstractGitflowBranchM
     @Parameter(defaultValue = "${repositorySystemSession}", required = true)
     RepositorySystemSession session;
 
-    @Parameter(property = "gitflow.force.other.deploy", defaultValue = "false", required = true)
-    String forceOtherDeploy;
+    @Parameter(property = "otherDeployBranchPattern", required = false)
+    String otherDeployBranchPattern;
 
     @Component
     private EnhancedLocalRepositoryManagerFactory localRepositoryManagerFactory;

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/AttachDeployedArtifactsMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/AttachDeployedArtifactsMojo.java
@@ -34,6 +34,9 @@ public class AttachDeployedArtifactsMojo extends AbstractGitflowBasedRepositoryM
                 attachExistingArtifacts(snapshotDeploymentRepository, true);
                 break;
             }
+            case OTHER: {
+
+            }
             default: {
                 getLog().info("Attaching Artifacts from local repository...");
                 // Use the 'local' repository to do this.

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/AttachDeployedArtifactsMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/AttachDeployedArtifactsMojo.java
@@ -1,5 +1,6 @@
 package com.e_gineering.maven.gitflowhelper;
 
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Execute;
@@ -35,7 +36,12 @@ public class AttachDeployedArtifactsMojo extends AbstractGitflowBasedRepositoryM
                 break;
             }
             case OTHER: {
-
+                String otherBranchesToDeploy = resolveExpression(otherDeployBranchPattern);
+                if (!"".equals(otherBranchesToDeploy) && gitBranchInfo.getName().matches(otherBranchesToDeploy)) {
+                    getLog().info("Attaching branch artifacts from snapshot repository...");
+                    attachExistingArtifacts(snapshotDeploymentRepository, true);
+                    break;
+                }
             }
             default: {
                 getLog().info("Attaching Artifacts from local repository...");

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/PromoteMasterMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/PromoteMasterMojo.java
@@ -1,12 +1,13 @@
 package com.e_gineering.maven.gitflowhelper;
 
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
 /**
- * If the build is being executed from a FEATURE_OR_BUGFIX, DEVELOPMENT, HOTFIX or RELEASE branch, attach an artifact containing a list of
+ * If the build is being executed from a DEVELOPMENT, HOTFIX or RELEASE branch, attach an artifact containing a list of
  * the attached artifacts. This list is then used for promoting artifacts from the stage repository to the release
  * repository. Or it can be used manually by the attach-deployed goal.
  *
@@ -25,6 +26,14 @@ public class PromoteMasterMojo extends AbstractGitflowBasedRepositoryMojo {
             case RELEASE: {
                 // In order to use promote-master or attach-deployed, we need to build an artifactCatalog on deployable branches.
                 attachArtifactCatalog();
+                break;
+            }
+            // In order to use attach-deployed, we need to build the artifactCatalog.
+            case OTHER: {
+                String otherBranchesToDeploy = resolveExpression(otherDeployBranchPattern);
+                if (!"".equals(otherBranchesToDeploy) && gitBranchInfo.getName().matches(otherBranchesToDeploy)) {
+                    attachArtifactCatalog();
+                }
                 break;
             }
 

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/RetargetDeployMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/RetargetDeployMojo.java
@@ -35,15 +35,12 @@ public class RetargetDeployMojo extends AbstractGitflowBasedRepositoryMojo {
                 break;
             }
             case OTHER: {
-                // If other branches are set to deploy
-                // Other branches never target release, but may target stage for non-SNAPSHOT artifacts.
-                // For this reason, "overwrite" is considered _highly_ dangerous.
                 String otherBranchesToDeploy = resolveExpression(otherDeployBranchPattern);
 	            if (!"".equals(otherBranchesToDeploy) && gitBranchInfo.getName().matches(otherBranchesToDeploy)) {
                     setTargetSnapshots();
 
                     String branchName = gitBranchInfo.getName();
-                    String semVerAddition = "+" + branchName.replaceAll("[^0-9^A-Z^a-z^-^.]", "-") + "-SNAPSHOT";
+                    String semVerAddition = "+" + branchName.replaceAll("[^0-9A-Za-z-.]", "-") + "-SNAPSHOT";
 
                     updateArtifactVersion(project.getArtifact(), semVerAddition);
                     for (Artifact a : project.getAttachedArtifacts()) {

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/RetargetDeployMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/RetargetDeployMojo.java
@@ -38,9 +38,7 @@ public class RetargetDeployMojo extends AbstractGitflowBasedRepositoryMojo {
                 // If other branches are set to deploy
                 // Other branches never target release, but may target stage for non-SNAPSHOT artifacts.
                 // For this reason, "overwrite" is considered _highly_ dangerous.
-                getLog().debug("Resolving: " + otherDeployBranchPattern);
                 String otherBranchesToDeploy = resolveExpression(otherDeployBranchPattern);
-                getLog().debug("Resolved to: " + otherBranchesToDeploy);
 	            if (!"".equals(otherBranchesToDeploy) && gitBranchInfo.getName().matches(otherBranchesToDeploy)) {
                     setTargetSnapshots();
 

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/RetargetDeployMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/RetargetDeployMojo.java
@@ -1,5 +1,7 @@
 package com.e_gineering.maven.gitflowhelper;
 
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.model.DistributionManagement;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -20,29 +22,94 @@ public class RetargetDeployMojo extends AbstractGitflowBasedRepositoryMojo {
         switch (gitBranchInfo.getType()) {
             case SUPPORT:
             case MASTER: {
-                getLog().info("Setting release artifact repository to: [" + releaseDeploymentRepository + "]");
-                project.setSnapshotArtifactRepository(null);
-                project.setReleaseArtifactRepository(getDeploymentRepository(releaseDeploymentRepository));
+                setTargetRelease();
                 break;
             }
             case RELEASE:
             case HOTFIX: {
-                getLog().info("Setting release artifact repository to: [" + stageDeploymentRepository + "]");
-                project.setSnapshotArtifactRepository(null);
-                project.setReleaseArtifactRepository(getDeploymentRepository(stageDeploymentRepository));
+                setTargetStage();
                 break;
             }
             case DEVELOPMENT: {
-                getLog().info("Setting snapshot artifact repository to: [" + snapshotDeploymentRepository + "]");
-                project.setSnapshotArtifactRepository(getDeploymentRepository(snapshotDeploymentRepository));
-                project.setReleaseArtifactRepository(null);
+                setTargetSnapshots();
                 break;
+            }
+            case OTHER: {
+                // Other branches never target release, but may target stage for non-SNAPSHOT artifacts.
+                // For this reason, "overwrite" is considered _highly_ dangerous.
+                if (!"false".equalsIgnoreCase(forceOtherDeploy)) {
+                    // Setup the target based on the base project version.
+                    if (ArtifactUtils.isSnapshot(project.getVersion())) {
+                        setTargetSnapshots();
+                    } else {
+                        setTargetStage();
+                    }
+
+                    // Monkey with things to do our semVer magic.
+                    if ("semVer".equalsIgnoreCase(forceOtherDeploy)) {
+                    	if (ArtifactUtils.isSnapshot(project.getVersion())) {
+                    		getLog().warn("Maven -SNAPSHOT builds break semVer standards, in that -SNAPSHOT must be the _last_ poriton of a maven version. In semVer, the pre-release status is supposed to come before the build meta-data.");
+                    		getLog().info("The gitflow-helper-maven-plugin will inject the build metadata preceding the -SNAPSHOT, allowing for snapshot deployments of this branch.");
+	                    }
+                        String branchName = gitBranchInfo.getName();
+                        String semVerAddition = "+" + branchName.replaceAll("[^0-9^A-Z^a-z^-^.]", "-");
+
+                        updateArtifactVersion(project.getArtifact(), semVerAddition);
+                        for (Artifact a : project.getAttachedArtifacts()) {
+                        	updateArtifactVersion(a, semVerAddition);
+                        }
+
+                        getLog().info("Artifact versions updated with semVer build metadata: " + semVerAddition);
+                    }
+                    if ("overwrite".equalsIgnoreCase(forceOtherDeploy)) {
+                        getLog().warn("DANGER! DANGER, WILL ROBINSON!");
+                        getLog().warn("Deployment of this build will OVERWRITE Deployment of " + project.getVersion() + " in the targeted repository.");
+                        getLog().warn("THIS IS NOT RECOMMENDED.");
+                    }
+                    break;
+                }
             }
             default: {
                 unsetRepos();
                 break;
             }
         }
+    }
+
+    private void updateArtifactVersion(final Artifact a, final String semVerAdditon) {
+    	String baseVersion = a.getBaseVersion();
+    	String version = a.getVersion();
+
+		String semBaseVersion = baseVersion + semVerAdditon;
+		String semVersion = version + semVerAdditon;
+
+		if (semBaseVersion.contains("-SNAPSHOT")) {
+			semBaseVersion = semBaseVersion.replace("-SNAPSHOT", "") + "-SNAPSHOT";
+		}
+		if (semVersion.contains("-SNAPSHOT")) {
+			semVersion = semVersion.replace("-SNAPSHOT", "") + "-SNAPSHOT";
+		}
+		a.setBaseVersion(semBaseVersion);
+		a.setVersion(semVersion);
+    }
+
+
+    private void setTargetSnapshots() throws MojoExecutionException, MojoFailureException {
+        getLog().info("Setting snapshot artifact repository to: [" + snapshotDeploymentRepository + "]");
+        project.setSnapshotArtifactRepository(getDeploymentRepository(snapshotDeploymentRepository));
+        project.setReleaseArtifactRepository(null);
+    }
+
+    private void setTargetStage() throws MojoExecutionException, MojoFailureException {
+        getLog().info("Setting release artifact repository to: [" + stageDeploymentRepository + "]");
+        project.setSnapshotArtifactRepository(null);
+        project.setReleaseArtifactRepository(getDeploymentRepository(stageDeploymentRepository));
+    }
+
+    private void setTargetRelease() throws MojoExecutionException, MojoFailureException {
+        getLog().info("Setting release artifact repository to: [" + releaseDeploymentRepository + "]");
+        project.setSnapshotArtifactRepository(null);
+        project.setReleaseArtifactRepository(getDeploymentRepository(releaseDeploymentRepository));
     }
 
     private void unsetRepos() {

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/SetPropertiesMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/SetPropertiesMojo.java
@@ -15,7 +15,7 @@ import java.util.Properties;
 /**
  * Set a project property value based upon the current ${env.GIT_BRANCH} resolution.
  */
-@Mojo(name = "set-properties", defaultPhase = LifecyclePhase.INITIALIZE, threadSafe = true)
+@Mojo(name = "set-properties", defaultPhase = LifecyclePhase.VALIDATE, threadSafe = true)
 public class SetPropertiesMojo extends AbstractGitflowBranchMojo {
 
     /**

--- a/src/test/java/com/e_gineering/maven/gitflowhelper/OtherBranchIT.java
+++ b/src/test/java/com/e_gineering/maven/gitflowhelper/OtherBranchIT.java
@@ -10,52 +10,65 @@ public class OtherBranchIT extends AbstractIntegrationTest {
 	@Test
 	public void featureSnapshotSemVer() throws Exception {
 		Verifier verifier = createVerifier("/project-stub", "origin/feature/poc/my-feature-branch", "5.0.0-SNAPSHOT");
-		verifier.executeGoal("deploy");
+		try {
+			verifier.executeGoal("deploy");
 
-		verifier.verifyTextInLog("Artifact versions updated with semVer build metadata: +origin-feature-poc-my-feature-branch-SNAPSHOT");
-		verifier.verifyErrorFreeLog();
-		verifier.resetStreams();
+			verifier.verifyTextInLog("Artifact versions updated with semVer build metadata: +origin-feature-poc-my-feature-branch-SNAPSHOT");
+			verifier.verifyErrorFreeLog();
+		} finally {
+			verifier.resetStreams();
+		}
 	}
 
 	@Test
 	public void featureSemVer() throws Exception {
 		Verifier verifier = createVerifier("/project-stub", "origin/feature/poc/my-feature-branch.with.other.identifiers", "5.0.1");
-		verifier.executeGoal("deploy");
+		try {
+			verifier.executeGoal("deploy");
 
-		verifier.verifyTextInLog("Artifact versions updated with semVer build metadata: +origin-feature-poc-my-feature-branch.with.other.identifiers-SNAPSHOT");
-		verifier.verifyErrorFreeLog();
-		verifier.resetStreams();
+			verifier.verifyTextInLog("Artifact versions updated with semVer build metadata: +origin-feature-poc-my-feature-branch.with.other.identifiers-SNAPSHOT");
+			verifier.verifyErrorFreeLog();
+		} finally {
+			verifier.resetStreams();
+		}
 	}
 
 	@Test
 	public void noOtherDeployMatch() throws Exception {
 		Verifier verifier = createVerifier("/project-stub", "origin/feature/my-feature-branch", "5.0.1-SNAPSHOT");
-		verifier.executeGoal("deploy");
+		try {
+			verifier.executeGoal("deploy");
 
-		verifier.verifyTextInLog("Un-Setting artifact repositories.");
-		verifier.verifyErrorFreeLog();
-		verifier.resetStreams();
+			verifier.verifyTextInLog("Un-Setting artifact repositories.");
+			verifier.verifyErrorFreeLog();
+		} finally {
+			verifier.resetStreams();
+		}
 	}
 
 	@Test
 	public void automagicVersionDependenciesResolve() throws Exception {
 		// Create a -SNAPSHOT of the project-stub.
 		Verifier verifier = createVerifier("/project-stub", "origin/feature/poc/long-running", "2.0.0");
+		try {
+			verifier.executeGoal("deploy");
 
-		verifier.executeGoal("deploy");
-
-		verifier.verifyTextInLog("Artifact versions updated with semVer build metadata: +origin-feature-poc-long-running-SNAPSHOT");
-		verifier.verifyErrorFreeLog();
-		verifier.resetStreams();
+			verifier.verifyTextInLog("Artifact versions updated with semVer build metadata: +origin-feature-poc-long-running-SNAPSHOT");
+			verifier.verifyErrorFreeLog();
+		} finally {
+			verifier.resetStreams();
+		}
 
 		// Create a -SNAPSHOT of the project-alt1-stub that depends upon the other project's automagic version.
 		verifier = createVerifier("/project-alt1-stub", "origin/feature/poc/long-running", "2.0.0");
+		try {
+			verifier.getCliOptions().add("-Ddependency.stub.version=2.0.0+origin-feature-poc-long-running-SNAPSHOT");
+			verifier.getCliOptions().add("-Dplugin.stub.version=2.0.0+origin-feature-poc-long-running-SNAPSHOT");
 
-		verifier.getCliOptions().add("-Ddependency.stub.version=2.0.0+origin-feature-poc-long-running-SNAPSHOT");
-		verifier.getCliOptions().add("-Dplugin.stub.version=2.0.0+origin-feature-poc-long-running-SNAPSHOT");
-
-		verifier.executeGoal("deploy");
-		verifier.verifyErrorFreeLog();
-		verifier.resetStreams();
+			verifier.executeGoal("deploy");
+			verifier.verifyErrorFreeLog();
+		} finally {
+			verifier.resetStreams();
+		}
 	}
 }

--- a/src/test/java/com/e_gineering/maven/gitflowhelper/OtherBranchIT.java
+++ b/src/test/java/com/e_gineering/maven/gitflowhelper/OtherBranchIT.java
@@ -9,58 +9,53 @@ import org.junit.runners.BlockJUnit4ClassRunner;
 public class OtherBranchIT extends AbstractIntegrationTest {
 	@Test
 	public void featureSnapshotSemVer() throws Exception {
-		Verifier verifier = createVerifier("/project-stub", "origin/feature/my-feature-branch", "5.0.0-SNAPSHOT");
-		try {
-			verifier.getCliOptions().add("-Dgitflow.force.other.deploy=semver");
-			verifier.executeGoal("deploy");
+		Verifier verifier = createVerifier("/project-stub", "origin/feature/poc/my-feature-branch", "5.0.0-SNAPSHOT");
+		verifier.executeGoal("deploy");
 
-			verifier.verifyTextInLog("Artifact versions updated with semVer build metadata: +origin-feature-my-feature-branch");
-			verifier.verifyErrorFreeLog();
-		} finally {
-			verifier.resetStreams();
-		}
-	}
-
-	@Test
-	public void featureSnapshotOverwrite() throws Exception {
-		Verifier verifier = createVerifier("/project-stub", "origin/feature/my-feature-branch", "5.0.0-SNAPSHOT");
-		try {
-			verifier.getCliOptions().add("-Dgitflow.force.other.deploy=overwrite");
-			verifier.executeGoal("deploy");
-
-			verifier.verifyTextInLog("DANGER! DANGER, WILL ROBINSON!");
-			verifier.verifyErrorFreeLog();
-		} finally {
-			verifier.resetStreams();
-		}
+		verifier.verifyTextInLog("Artifact versions updated with semVer build metadata: +origin-feature-poc-my-feature-branch-SNAPSHOT");
+		verifier.verifyErrorFreeLog();
+		verifier.resetStreams();
 	}
 
 	@Test
 	public void featureSemVer() throws Exception {
-		Verifier verifier = createVerifier("/project-stub", "origin/feature/my-feature-branch.with.other.identifiers", "5.0.1");
-		try {
-			verifier.getCliOptions().add("-Dgitflow.force.other.deploy=semver");
-			verifier.executeGoal("deploy");
+		Verifier verifier = createVerifier("/project-stub", "origin/feature/poc/my-feature-branch.with.other.identifiers", "5.0.1");
+		verifier.executeGoal("deploy");
 
-			verifier.verifyTextInLog("Artifact versions updated with semVer build metadata: +origin-feature-my-feature-branch.with.other.identifiers");
-			verifier.verifyErrorFreeLog();
-		} finally {
-			verifier.resetStreams();
-		}
+		verifier.verifyTextInLog("Artifact versions updated with semVer build metadata: +origin-feature-poc-my-feature-branch.with.other.identifiers-SNAPSHOT");
+		verifier.verifyErrorFreeLog();
+		verifier.resetStreams();
 	}
 
 	@Test
-	public void featureOverwrite() throws Exception {
-		Verifier verifier = createVerifier("/project-stub", "origin/feature/my-feature-branch", "5.0.1");
-		try {
-			verifier.getCliOptions().add("-Dgitflow.force.other.deploy=overwrite");
-			verifier.executeGoal("deploy");
+	public void noOtherDeployMatch() throws Exception {
+		Verifier verifier = createVerifier("/project-stub", "origin/feature/my-feature-branch", "5.0.1-SNAPSHOT");
+		verifier.executeGoal("deploy");
 
-			verifier.verifyTextInLog("DANGER! DANGER, WILL ROBINSON!");
-			verifier.verifyErrorFreeLog();
-		} finally {
-			verifier.resetStreams();
-		}
+		verifier.verifyTextInLog("Un-Setting artifact repositories.");
+		verifier.verifyErrorFreeLog();
+		verifier.resetStreams();
 	}
 
+	@Test
+	public void automagicVersionDependenciesResolve() throws Exception {
+		// Create a -SNAPSHOT of the project-stub.
+		Verifier verifier = createVerifier("/project-stub", "origin/feature/poc/long-running", "2.0.0");
+
+		verifier.executeGoal("deploy");
+
+		verifier.verifyTextInLog("Artifact versions updated with semVer build metadata: +origin-feature-poc-long-running-SNAPSHOT");
+		verifier.verifyErrorFreeLog();
+		verifier.resetStreams();
+
+		// Create a -SNAPSHOT of the project-alt1-stub that depends upon the other project's automagic version.
+		verifier = createVerifier("/project-alt1-stub", "origin/feature/poc/long-running", "2.0.0");
+
+		verifier.getCliOptions().add("-Ddependency.stub.version=2.0.0+origin-feature-poc-long-running-SNAPSHOT");
+		verifier.getCliOptions().add("-Dplugin.stub.version=2.0.0+origin-feature-poc-long-running-SNAPSHOT");
+
+		verifier.executeGoal("deploy");
+		verifier.verifyErrorFreeLog();
+		verifier.resetStreams();
+	}
 }

--- a/src/test/java/com/e_gineering/maven/gitflowhelper/OtherBranchIT.java
+++ b/src/test/java/com/e_gineering/maven/gitflowhelper/OtherBranchIT.java
@@ -1,0 +1,66 @@
+package com.e_gineering.maven.gitflowhelper;
+
+import org.apache.maven.it.Verifier;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
+
+@RunWith(BlockJUnit4ClassRunner.class)
+public class OtherBranchIT extends AbstractIntegrationTest {
+	@Test
+	public void featureSnapshotSemVer() throws Exception {
+		Verifier verifier = createVerifier("/project-stub", "origin/feature/my-feature-branch", "5.0.0-SNAPSHOT");
+		try {
+			verifier.getCliOptions().add("-Dgitflow.force.other.deploy=semver");
+			verifier.executeGoal("deploy");
+
+			verifier.verifyTextInLog("Artifact versions updated with semVer build metadata: +origin-feature-my-feature-branch");
+			verifier.verifyErrorFreeLog();
+		} finally {
+			verifier.resetStreams();
+		}
+	}
+
+	@Test
+	public void featureSnapshotOverwrite() throws Exception {
+		Verifier verifier = createVerifier("/project-stub", "origin/feature/my-feature-branch", "5.0.0-SNAPSHOT");
+		try {
+			verifier.getCliOptions().add("-Dgitflow.force.other.deploy=overwrite");
+			verifier.executeGoal("deploy");
+
+			verifier.verifyTextInLog("DANGER! DANGER, WILL ROBINSON!");
+			verifier.verifyErrorFreeLog();
+		} finally {
+			verifier.resetStreams();
+		}
+	}
+
+	@Test
+	public void featureSemVer() throws Exception {
+		Verifier verifier = createVerifier("/project-stub", "origin/feature/my-feature-branch.with.other.identifiers", "5.0.1");
+		try {
+			verifier.getCliOptions().add("-Dgitflow.force.other.deploy=semver");
+			verifier.executeGoal("deploy");
+
+			verifier.verifyTextInLog("Artifact versions updated with semVer build metadata: +origin-feature-my-feature-branch.with.other.identifiers");
+			verifier.verifyErrorFreeLog();
+		} finally {
+			verifier.resetStreams();
+		}
+	}
+
+	@Test
+	public void featureOverwrite() throws Exception {
+		Verifier verifier = createVerifier("/project-stub", "origin/feature/my-feature-branch", "5.0.1");
+		try {
+			verifier.getCliOptions().add("-Dgitflow.force.other.deploy=overwrite");
+			verifier.executeGoal("deploy");
+
+			verifier.verifyTextInLog("DANGER! DANGER, WILL ROBINSON!");
+			verifier.verifyErrorFreeLog();
+		} finally {
+			verifier.resetStreams();
+		}
+	}
+
+}

--- a/src/test/java/com/e_gineering/maven/gitflowhelper/OtherBranchIT.java
+++ b/src/test/java/com/e_gineering/maven/gitflowhelper/OtherBranchIT.java
@@ -5,6 +5,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.BlockJUnit4ClassRunner;
 
+import java.util.Arrays;
+
 @RunWith(BlockJUnit4ClassRunner.class)
 public class OtherBranchIT extends AbstractIntegrationTest {
 	@Test
@@ -66,6 +68,27 @@ public class OtherBranchIT extends AbstractIntegrationTest {
 			verifier.getCliOptions().add("-Dplugin.stub.version=2.0.0+origin-feature-poc-long-running-SNAPSHOT");
 
 			verifier.executeGoal("deploy");
+			verifier.verifyErrorFreeLog();
+		} finally {
+			verifier.resetStreams();
+		}
+	}
+
+	@Test
+	public void attachDeployed() throws Exception {
+		Verifier verifier = createVerifier("/project-stub", "origin/feature/poc/reattach", "5.0.0-SNAPSHOT");
+		try {
+			verifier.executeGoal("deploy");
+
+			verifier.verifyTextInLog("Artifact versions updated with semVer build metadata: +origin-feature-poc-reattach-SNAPSHOT");
+			verifier.verifyErrorFreeLog();
+		} finally {
+			verifier.resetStreams();
+		}
+
+		verifier = createVerifier("/project-stub", "origin/feature/poc/reattach", "5.0.0-SNAPSHOT");
+		try {
+			verifier.executeGoals(Arrays.asList("validate", "gitflow-helper:attach-deployed"));
 			verifier.verifyErrorFreeLog();
 		} finally {
 			verifier.resetStreams();

--- a/src/test/resources/project-alt1-stub/pom.xml
+++ b/src/test/resources/project-alt1-stub/pom.xml
@@ -56,15 +56,15 @@
 					<releaseBranchProperties>
 						<foo>bar</foo>
 					</releaseBranchProperties>
-					<scope>system</scope>
+					<otherDeployBranchPattern>(origin/)feature/poc/.*</otherDeployBranchPattern>
 				</configuration>
 				<executions>
 					<execution>
 						<goals>
 							<goal>enforce-versions</goal>
+							<goal>set-properties</goal>
 							<goal>retarget-deploy</goal>
 							<goal>update-stage-dependencies</goal>
-							<goal>set-properties</goal>
 							<goal>promote-master</goal>
 						</goals>
 					</execution>

--- a/src/test/resources/project-alt1-stub/pom.xml
+++ b/src/test/resources/project-alt1-stub/pom.xml
@@ -56,7 +56,7 @@
 					<releaseBranchProperties>
 						<foo>bar</foo>
 					</releaseBranchProperties>
-					<otherDeployBranchPattern>(origin/)feature/poc/.*</otherDeployBranchPattern>
+					<otherDeployBranchPattern>(origin/)?feature/poc/.*</otherDeployBranchPattern>
 				</configuration>
 				<executions>
 					<execution>

--- a/src/test/resources/project-stub/pom.xml
+++ b/src/test/resources/project-stub/pom.xml
@@ -69,14 +69,15 @@
 					<undefinedBranchProperties>
 						<build.branch.type>undefined</build.branch.type>
 					</undefinedBranchProperties>
+					<otherDeployBranchPattern>(origin/)feature/poc/.*</otherDeployBranchPattern>
 				</configuration>
 				<executions>
 					<execution>
 						<goals>
 							<goal>enforce-versions</goal>
+							<goal>set-properties</goal>
 							<goal>retarget-deploy</goal>
 							<goal>update-stage-dependencies</goal>
-							<goal>set-properties</goal>
 						</goals>
 					</execution>
 					<execution>

--- a/src/test/resources/project-stub/pom.xml
+++ b/src/test/resources/project-stub/pom.xml
@@ -69,7 +69,7 @@
 					<undefinedBranchProperties>
 						<build.branch.type>undefined</build.branch.type>
 					</undefinedBranchProperties>
-					<otherDeployBranchPattern>(origin/)feature/poc/.*</otherDeployBranchPattern>
+					<otherDeployBranchPattern>(origin/)?feature/poc/.*</otherDeployBranchPattern>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
Introduces `otherDeploymentBranchPattern`, a regex that can match against any non-versioned (other, bugfix, feature, etc.) branch name pattern to force the following:

* Automatic injection of the branch name (normalized to conform with semVer) into the resultant artifacts version string.
* Forced addition of `-SNAPSHOT` to the artifacts version strings.
* Deployment of these snapshot artifacts to the Snapshots repository.

This should fulfill the spirit of the changes that were added in 1.8.0 as a consequence of merging #83 and #84, but in a slightly more configurable manner, and without the negative impact on the feature and bugfix branch version enforcement called out in #87