### PR TITLE
Feature/m2e mappings

### DIFF
--- a/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -4,16 +4,27 @@
     <pluginExecution>
       <pluginExecutionFilter>
         <goals>
-          <goal>enforce-versions</goal>
-          <goal>retarget-deploy</goal>
-          <goal>update-stage-dependencies</goal>
-          <goal>set-properties</goal>
           <goal>tag-master</goal>
+          <goal>retarget-deploy</goal>
           <goal>promote-master</goal>
         </goals>
       </pluginExecutionFilter>
       <action>
         <ignore />
+      </action>
+    </pluginExecution>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>enforce-versions</goal>
+          <goal>set-properties</goal>
+          <goal>update-stage-dependencies</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <execute>
+          <runOnIncremental>false</runOnIncremental>
+        </execute>
       </action>
     </pluginExecution>
   </pluginExecutions>


### PR DESCRIPTION
Pulls in some m2e mappings to execute a few things (enforce-versions, set-properties, updating stage dependencies) and ignore a few others (anything related to artifact creation / promotion / deployment) within Eclipse IDE.

I tested this within Eclipse, it worked about how I expected it should.