### PR TITLE
allow for overriding delimiter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,11 +256,15 @@ Can be replaced with the following plugin configuration, which also introduces t
 
 In addition to setting up repository targets for release branches, the `retarget-depoy` branch can deploy other branches
 matching the `otherDeploymentBranchPattern` as -SNAPSHOT artifacts which include the branch name as build metadata.
-This is loosely based on the [semVer](https://semver.org) semantic version scheme, in that the plugin will reversion any
-artifacts to be produced with `+feature-branch-name-normalized-SNAPSHOT` where any characters not in `[0-9A-Za-z-.]` will
-be replaced with `-`. Artifact versions for feature branches will _always_ be -SNAPSHOT, and will _always_ target the 
+By default this is loosely based on the [semVer](https://semver.org) semantic version scheme, in that the plugin will 
+reversion any artifacts to be produced with `+feature-branch-name-normalized-SNAPSHOT` where any characters not in 
+`[0-9A-Za-z-.]` will be replaced with `-`. In cases where the `+` delimiter is problematic, you can override that default
+by specifying `<otherBranchVersionDelimiter>` in your configuration block.
+
+Using this feature, artifact versions for feature branches will _always_ be -SNAPSHOT, and will _always_ target the 
 Snapshots repository. The intent for this configuration setting is to provide a way for long-running branches (matching 
-a naming convention you define) can be published to a SNAPSHOT repo for use by other projects.
+a naming convention you define) can be published to a SNAPSHOT repo for use by other projects, and to prevent feature 
+branches forked from release branches from mangling the test release in an artifact repository.
 
 ## Goal: `update-stage-dependencies` (Force update of dependency staged Releases)
 

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBasedRepositoryMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBasedRepositoryMojo.java
@@ -87,6 +87,9 @@ abstract class AbstractGitflowBasedRepositoryMojo extends AbstractGitflowBranchM
     @Parameter(property = "otherDeployBranchPattern", required = false)
     String otherDeployBranchPattern;
 
+    @Parameter(defaultValue = "+", required = true)
+    String otherBranchVersionDelimiter;
+
     @Component
     private EnhancedLocalRepositoryManagerFactory localRepositoryManagerFactory;
 

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/RetargetDeployMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/RetargetDeployMojo.java
@@ -47,7 +47,7 @@ public class RetargetDeployMojo extends AbstractGitflowBasedRepositoryMojo {
                         updateArtifactVersion(a, gitBranchInfo.getName());
                     }
 
-                    getLog().info("Artifact versions updated with semVer build metadata: " + getAsBranchSnapshotVersion("", gitBranchInfo.getName()));
+                    getLog().info("Artifact versions updated with build metadata: " + getAsBranchSnapshotVersion("", gitBranchInfo.getName()));
                     break;
                 }
             }
@@ -84,8 +84,7 @@ public class RetargetDeployMojo extends AbstractGitflowBasedRepositoryMojo {
      * @return A mangled version string with the branchname and -SNAPSHOT.
      */
     private String getAsBranchSnapshotVersion(final String version, final String branchName) {
-        return version.replace("-SNAPSHOT", "") + "+" + branchName.replaceAll("[^0-9A-Za-z-.]", "-") + "-SNAPSHOT";
-
+        return version.replace("-SNAPSHOT", "") + otherBranchVersionDelimiter + branchName.replaceAll("[^0-9A-Za-z-.]", "-") + "-SNAPSHOT";
     }
 
     private void setTargetSnapshots() throws MojoExecutionException, MojoFailureException {

--- a/src/test/java/com/e_gineering/maven/gitflowhelper/OtherBranchIT.java
+++ b/src/test/java/com/e_gineering/maven/gitflowhelper/OtherBranchIT.java
@@ -15,7 +15,7 @@ public class OtherBranchIT extends AbstractIntegrationTest {
 		try {
 			verifier.executeGoal("deploy");
 
-			verifier.verifyTextInLog("Artifact versions updated with semVer build metadata: +origin-feature-poc-my-feature-branch-SNAPSHOT");
+			verifier.verifyTextInLog("Artifact versions updated with build metadata: +origin-feature-poc-my-feature-branch-SNAPSHOT");
 			verifier.verifyErrorFreeLog();
 		} finally {
 			verifier.resetStreams();
@@ -28,7 +28,7 @@ public class OtherBranchIT extends AbstractIntegrationTest {
 		try {
 			verifier.executeGoal("deploy");
 
-			verifier.verifyTextInLog("Artifact versions updated with semVer build metadata: +origin-feature-poc-my-feature-branch.with.other.identifiers-SNAPSHOT");
+			verifier.verifyTextInLog("Artifact versions updated with build metadata: +origin-feature-poc-my-feature-branch.with.other.identifiers-SNAPSHOT");
 			verifier.verifyErrorFreeLog();
 		} finally {
 			verifier.resetStreams();
@@ -55,19 +55,21 @@ public class OtherBranchIT extends AbstractIntegrationTest {
 		try {
 			verifier.executeGoal("deploy");
 
-			verifier.verifyTextInLog("Artifact versions updated with semVer build metadata: +origin-feature-poc-long-running-SNAPSHOT");
+			verifier.verifyTextInLog("Artifact versions updated with build metadata: +origin-feature-poc-long-running-SNAPSHOT");
 			verifier.verifyErrorFreeLog();
 		} finally {
 			verifier.resetStreams();
 		}
 
 		// Create a -SNAPSHOT of the project-alt1-stub that depends upon the other project's automagic version.
+		// The alt project defines a `-` as the otherBranchVersionDelimiter.
 		verifier = createVerifier("/project-alt1-stub", "origin/feature/poc/long-running", "2.0.0");
 		try {
 			verifier.getCliOptions().add("-Ddependency.stub.version=2.0.0+origin-feature-poc-long-running-SNAPSHOT");
 			verifier.getCliOptions().add("-Dplugin.stub.version=2.0.0+origin-feature-poc-long-running-SNAPSHOT");
 
 			verifier.executeGoal("deploy");
+			verifier.verifyTextInLog("Artifact versions updated with build metadata: -origin-feature-poc-long-running-SNAPSHOT");
 			verifier.verifyErrorFreeLog();
 		} finally {
 			verifier.resetStreams();
@@ -80,7 +82,7 @@ public class OtherBranchIT extends AbstractIntegrationTest {
 		try {
 			verifier.executeGoal("deploy");
 
-			verifier.verifyTextInLog("Artifact versions updated with semVer build metadata: +origin-feature-poc-reattach-SNAPSHOT");
+			verifier.verifyTextInLog("Artifact versions updated with build metadata: +origin-feature-poc-reattach-SNAPSHOT");
 			verifier.verifyErrorFreeLog();
 		} finally {
 			verifier.resetStreams();

--- a/src/test/resources/project-alt1-stub/pom.xml
+++ b/src/test/resources/project-alt1-stub/pom.xml
@@ -57,6 +57,7 @@
 						<foo>bar</foo>
 					</releaseBranchProperties>
 					<otherDeployBranchPattern>(origin/)?feature/poc/.*</otherDeployBranchPattern>
+					<otherBranchVersionDelimiter>-</otherBranchVersionDelimiter>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
Many other opinionated systems don't like having `+` in the version string.

Specifically, you can't use that within say, a docker tag.