### PR TITLE
Prepping for a 3.0 release with breaking changes to toolsets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It does so by:
  * Enforcing [gitflow](http://nvie.com/posts/a-successful-git-branching-model/) version heuristics in [Maven](http://maven.apache.org/) projects.
  * Coercing Maven to gracefully support the gitflow workflow without imposing complex CI job configurations or complex Maven setups.
     * Setting distributionManagement repositories (for things like [maven-deploy-plugin](https://maven.apache.org/plugins/maven-deploy-plugin/)) based upon the current git branch.
-    * SCM tagging builds for master and support branches. You can use the project SCM definition, or if you omit it, you can resolve the CI server's repository connection information. (Zero Maven scm configuration necessary)
+    * SCM tagging builds for master and support branches. You can use the project SCM definition, or if you omit it, you canO resolve the CI server's repository connection information. (Zero Maven scm configuration necessary)
     * Promoting existing tested (staged) artifacts for release, rather than re-building the artifacts. Eliminates the risk of accidental master merges or commits resulting in untested code being released, and provides digest hash traceability for the history of artifacts.
     * Enabling the decoupling of repository deployment and execution environment delivery based on the current git branch.
     * Allowing for long-running non-release branches to be deployed to snapshots, automatically reversioning the artifacts based off the branch name.
@@ -110,7 +110,7 @@ All of the solutions to these issues are implemented independently in different 
                     <stageDeploymentRepository>localnexus-stage</stageDeploymentRepository>
                     <snapshotDeploymentRepository>localnexus-snapshots</snapshotDeploymentRepository>
                     <!-- Allow branches starting with feature/poc to be published as automagically versioned branch-name-SNAPSHOT artifacts -->
-                    <otherDeployBranchPattern>(origin/)feature/poc/.*</otherDeployBranchPattern>
+                    <otherDeployBranchPattern>(origin/)?feature/poc/.*</otherDeployBranchPattern>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <prerequisites>
-        <maven>3.1</maven>
+        <maven>3.6.0</maven>
     </prerequisites>
 
     <groupId>com.e-gineering</groupId>
     <artifactId>gitflow-helper-maven-plugin</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
 
     <packaging>maven-plugin</packaging>
 
@@ -49,8 +49,8 @@
     </scm>
 
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <it.repository.basedir>${project.build.directory}/it-repositories</it.repository.basedir>
         <version.gitflow.plugin>${project.version}</version.gitflow.plugin>
@@ -71,51 +71,51 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>3.1.0</version>
+            <version>3.6.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-compat</artifactId>
-            <version>3.1.0</version>
+            <version>3.6.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.1.0</version>
+            <version>3.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.scm</groupId>
             <artifactId>maven-scm-api</artifactId>
-            <version>1.9.5</version>
+            <version>1.11.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.scm</groupId>
             <artifactId>maven-scm-manager-plexus</artifactId>
-            <version>1.9.5</version>
+            <version>1.11.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.scm</groupId>
             <artifactId>maven-scm-provider-gitexe</artifactId>
-            <version>1.9.5</version>
+            <version>1.11.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.1</version>
+            <version>3.6.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-aether-provider</artifactId>
-            <version>3.1.0</version>
+            <version>3.3.9</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.aether</groupId>
             <artifactId>aether-util</artifactId>
-            <version>0.9.0.M2</version>
+            <version>1.1.0</version>
         </dependency>
     </dependencies>
 
@@ -189,7 +189,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.1</version>
+                        <version>0.8.4</version>
                         <executions>
                             <execution>
                                 <id>default-prepare-agent</id>
@@ -217,7 +217,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.22.0</version>
+                        <version>2.22.2</version>
                         <configuration>
                             <systemProperties>
                                 <argLine>${argLine}</argLine>
@@ -230,7 +230,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.22.0</version>
+                        <version>2.22.2</version>
                         <executions>
                             <execution>
                                 <configuration>

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBasedRepositoryMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/AbstractGitflowBasedRepositoryMojo.java
@@ -39,10 +39,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -68,7 +68,7 @@ abstract class AbstractGitflowBasedRepositoryMojo extends AbstractGitflowBranchM
     }
 
     private static PrintWriter newPrintWriter(File catalog) throws FileNotFoundException {
-        checkNotNull(catalog, "catalog must not be null");
+        Objects.requireNonNull(catalog, "catalog must not be null");
         return new PrintWriter(new OutputStreamWriter(new FileOutputStream(catalog), UTF_8));
     }
 

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/DefaultGavCoordinateHelper.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/DefaultGavCoordinateHelper.java
@@ -1,6 +1,6 @@
 package com.e_gineering.maven.gitflowhelper;
 
-import com.google.common.base.Joiner;
+import org.apache.commons.lang.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.logging.Logger;
@@ -8,17 +8,13 @@ import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.resolution.ArtifactResult;
 
 import javax.annotation.Nullable;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Strings.emptyToNull;
+import java.util.Objects;
 
 /**
  * A helper factory for creating maven (GroupId, ArtifactId, Extension, Classifier, Version) coordinates.
  */
 class DefaultGavCoordinateHelper implements GavCoordinateHelper {
-
-    private static final Joiner GAV_JOINER = Joiner.on(':').skipNulls();
-
+    
     private final Logger log;
 
     private final MavenProject project;
@@ -33,9 +29,9 @@ class DefaultGavCoordinateHelper implements GavCoordinateHelper {
      * @param log     the logger
      */
     DefaultGavCoordinateHelper(RepositorySystemSession session, MavenProject project, Logger log) {
-        this.session = checkNotNull(session, "session must not be null");
-        this.project = checkNotNull(project, "project must not be null");
-        this.log = checkNotNull(log, "log must not be null");
+        this.session = Objects.requireNonNull(session, "session must not be null");
+        this.project = Objects.requireNonNull(project, "project must not be null");
+        this.log = Objects.requireNonNull(log, "log must not be null");
     }
 
     @Override
@@ -52,6 +48,10 @@ class DefaultGavCoordinateHelper implements GavCoordinateHelper {
                 emptyToNull(artifact.getExtension()),
                 emptyToNull(artifact.getClassifier())
         );
+    }
+    
+    private static String emptyToNull(final String s) {
+        return StringUtils.isBlank(s) ? null : s;
     }
 
     @Override
@@ -89,9 +89,19 @@ class DefaultGavCoordinateHelper implements GavCoordinateHelper {
                                   String version,
                                   @Nullable String extension,
                                   @Nullable String classifier) {
-        checkNotNull(groupId, "groupId must not be null");
-        checkNotNull(artifactId, "artifactId must not be null");
-        checkNotNull(version, "version must not be null");
-        return GAV_JOINER.join(groupId, artifactId, extension, classifier, version);
+        Objects.requireNonNull(groupId, "groupId must not be null");
+        Objects.requireNonNull(artifactId, "artifactId must not be null");
+        Objects.requireNonNull(version, "version must not be null");
+        
+        StringBuilder result = new StringBuilder();
+        for (String s : new String[]{groupId, artifactId, extension, classifier, version}) {
+            if (s != null) {
+                if (result.length() > 0) {
+                    result.append(":");
+                }
+                result.append(s);
+            }
+        }
+        return result.toString();
     }
 }


### PR DESCRIPTION
* Bumping dependencies to Maven 3.6.0
* JDK 8

Guava was removed from Maven 3.6.0, and the older guava version had a few CVEs against it. So it was worth removing to cut dependencies.