### PR TITLE
Extended the OtherBranchVersionExtension to deal with partial multi-module builds

### DIFF
--- a/src/main/java/com/e_gineering/maven/gitflowhelper/OtherBranchVersionExtension.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/OtherBranchVersionExtension.java
@@ -91,18 +91,14 @@ public class OtherBranchVersionExtension extends AbstractBranchDetectingExtensio
 
                             logger.info("Found top level project, but outside reactor: " + topLevelProject.getGroupId() + ":" + topLevelProject.getArtifactId() + " (" + topLevelProject.getFile() + ")");
 
-                            // Initialization of the nested Maven execution
-                            final MavenExecutionRequest request = new DefaultMavenExecutionRequest()
-                                            .setLocalRepository(session.getLocalRepository())
-                                            .setPom(topLevelProject.getFile())
-                                            .setBaseDirectory(topLevelProject.getBasedir())
-                                            .setReactorFailureBehavior(MavenExecutionRequest.REACTOR_FAIL_NEVER)
-                                            .setUserProperties(session.getUserProperties())
-                                            .setMirrors(session.getRequest().getMirrors())
-                                            .setRemoteRepositories(session.getRequest().getRemoteRepositories())
-                                            .setPluginArtifactRepositories(session.getRequest().getPluginArtifactRepositories())
-                                            .setServers(session.getRequest().getServers())
-                                            .setProxies(session.getRequest().getProxies())
+                            // Initialization of the nested Maven execution, based on the current session's request
+                            final MavenExecutionRequest request = DefaultMavenExecutionRequest.copy(session.getRequest())
+                                    .setExecutionListener(null) /* Disable the observer of the outer maven session */
+                                    .setTransferListener(null) /* Disable the observer of the outer maven session */
+                                    .setGoals(null) /* Disable the goals used to execute the outer maven session */
+                                    .setReactorFailureBehavior(MavenExecutionRequest.REACTOR_FAIL_NEVER)
+                                    .setPom(topLevelProject.getFile()) /* Use the pom file of the top-level project */
+                                    .setBaseDirectory(topLevelProject.getBasedir()) /* Use the basedir of the top-level project */
                                     ;
                             // The following user property on the nested execution prevents this extension to activate
                             // in the nested execution. This is needed, as the extension is not reentrant.

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/OtherBranchVersionExtension.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/OtherBranchVersionExtension.java
@@ -97,6 +97,8 @@ public class OtherBranchVersionExtension extends AbstractBranchDetectingExtensio
                                             .setMirrors(session.getRequest().getMirrors())
                                             .setRemoteRepositories(session.getRequest().getRemoteRepositories())
                                             .setPluginArtifactRepositories(session.getRequest().getPluginArtifactRepositories())
+                                            .setServers(session.getRequest().getServers())
+                                            .setProxies(session.getRequest().getProxies())
                                     ;
                             // The following user property on the nested execution prevents this extension to activate
                             // in the nested execution. This is needed, as the extension is not reentrant.

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/OtherBranchVersionExtension.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/OtherBranchVersionExtension.java
@@ -288,14 +288,18 @@ public class OtherBranchVersionExtension extends AbstractBranchDetectingExtensio
     
     /**
      * Given a String version (which may be a final or -SNAPSHOT version) return a
-     * version version string mangled to include a `+normalized-branch-name-SNAPSHOT format version.
+     * version string mangled to include a `+normalized-branch-name-SNAPSHOT format version.
      *
      * @param version The base version (ie, 1.0.2-SNAPSHOT)
      * @param branchName to be normalized
      * @return A mangled version string with the branchname and -SNAPSHOT.
      */
-    private String getAsBranchSnapshotVersion(final String version, final String branchName) {
-        return version.replace("-SNAPSHOT", "") + otherBranchVersionDelimiter + branchName.replaceAll("[^0-9A-Za-z-.]", "-") + "-SNAPSHOT";
+    public String getAsBranchSnapshotVersion(final String version, final String branchName) {
+        String branchNameSanitized = otherBranchVersionDelimiter + branchName.replaceAll("[^0-9A-Za-z-.]", "-") + "-SNAPSHOT";
+        if(version.endsWith(branchNameSanitized)) {
+            return version;
+        }
+        return version.replace("-SNAPSHOT", "") + branchNameSanitized;
     }
     
 }

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/OtherBranchVersionExtension.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/OtherBranchVersionExtension.java
@@ -94,6 +94,9 @@ public class OtherBranchVersionExtension extends AbstractBranchDetectingExtensio
                                             .setBaseDirectory(topLevelProject.getBasedir())
                                             .setReactorFailureBehavior(MavenExecutionRequest.REACTOR_FAIL_NEVER)
                                             .setUserProperties(session.getUserProperties())
+                                            .setMirrors(session.getRequest().getMirrors())
+                                            .setRemoteRepositories(session.getRequest().getRemoteRepositories())
+                                            .setPluginArtifactRepositories(session.getRequest().getPluginArtifactRepositories())
                                     ;
                             // The following user property on the nested execution prevents this extension to activate
                             // in the nested execution. This is needed, as the extension is not reentrant.

--- a/src/test/java/com/e_gineering/maven/gitflowhelper/OtherBranchTest.java
+++ b/src/test/java/com/e_gineering/maven/gitflowhelper/OtherBranchTest.java
@@ -1,0 +1,33 @@
+package com.e_gineering.maven.gitflowhelper;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
+
+@RunWith(BlockJUnit4ClassRunner.class)
+public class OtherBranchTest {
+
+    private final String baseVersion = "1.0.2";
+    private final String baseSnapshotVersion = "1.0.2-SNAPSHOT";
+    private final String branchName = "feature/other-branch-name";
+    private final String expectedSnapshotResult = "1.0.2+feature-other-branch-name-SNAPSHOT";
+
+    private OtherBranchVersionExtension getExtension() {
+        OtherBranchVersionExtension extension = new OtherBranchVersionExtension();
+        extension.otherBranchVersionDelimiter = "+";
+        return extension;
+    }
+
+    @Test
+    public void assertOtherBranchNameIsPrefixedBeforeSnapshot() {
+        OtherBranchVersionExtension extension = getExtension();
+        Assert.assertEquals(expectedSnapshotResult, extension.getAsBranchSnapshotVersion(baseSnapshotVersion,branchName));
+    }
+
+    @Test
+    public void assertOtherBranchNameIsOnlyPrefixedBeforeSnapshotOneTime() {
+        OtherBranchVersionExtension extension = getExtension();
+        Assert.assertEquals(expectedSnapshotResult, extension.getAsBranchSnapshotVersion(extension.getAsBranchSnapshotVersion(baseSnapshotVersion,branchName),branchName));
+    }
+}


### PR DESCRIPTION
This change builds on the pending support for OtherBranch deployment properly supporting multi-module builds, and adds the ability to do partial builds after an initial full multi-module build.

This addition tries to detect whether the current build is a partial build. When it finds this to be the case, it bootstraps another Maven execution on the actual top-level project in order to get the _full picture_ of all projects in the multi-module build. The projects that are outside the reactor in the primary build are added to the cross-walk map, and from there on the original code is able to also update references to projects that are outside the reactor, but are part of the multi-module project.

The OtherDeployIT is extended with two tests that verify both the full and partial build behaviour of multi-module projects in a branch matching the otherDeployBranchPattern.