### PR TITLE
Prevent repeated OtherBranch name suffixes being appended

### DIFF
--- a/src/main/java/com/e_gineering/maven/gitflowhelper/OtherBranchVersionExtension.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/OtherBranchVersionExtension.java
@@ -224,7 +224,7 @@ public class OtherBranchVersionExtension extends AbstractBranchDetectingExtensio
      * @param branchName to be normalized
      * @return A mangled version string with the branchname and -SNAPSHOT.
      */
-    private String getAsBranchSnapshotVersion(final String version, final String branchName) {
+    public String getAsBranchSnapshotVersion(final String version, final String branchName) {
         String branchNameSanitized = otherBranchVersionDelimiter + branchName.replaceAll("[^0-9A-Za-z-.]", "-") + "-SNAPSHOT";
         if(version.endsWith(branchNameSanitized)) {
             return version;

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/OtherBranchVersionExtension.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/OtherBranchVersionExtension.java
@@ -218,14 +218,18 @@ public class OtherBranchVersionExtension extends AbstractBranchDetectingExtensio
     
     /**
      * Given a String version (which may be a final or -SNAPSHOT version) return a
-     * version version string mangled to include a `+normalized-branch-name-SNAPSHOT format version.
+     * version string mangled to include a `+normalized-branch-name-SNAPSHOT format version.
      *
      * @param version The base version (ie, 1.0.2-SNAPSHOT)
      * @param branchName to be normalized
      * @return A mangled version string with the branchname and -SNAPSHOT.
      */
     private String getAsBranchSnapshotVersion(final String version, final String branchName) {
-        return version.replace("-SNAPSHOT", "") + otherBranchVersionDelimiter + branchName.replaceAll("[^0-9A-Za-z-.]", "-") + "-SNAPSHOT";
+        String branchNameSanitized = otherBranchVersionDelimiter + branchName.replaceAll("[^0-9A-Za-z-.]", "-") + "-SNAPSHOT";
+        if(version.endsWith(branchNameSanitized)) {
+            return version;
+        }
+        return version.replace("-SNAPSHOT", "") + branchNameSanitized;
     }
     
 }

--- a/src/test/java/com/e_gineering/maven/gitflowhelper/OtherBranchTest.java
+++ b/src/test/java/com/e_gineering/maven/gitflowhelper/OtherBranchTest.java
@@ -1,0 +1,33 @@
+package com.e_gineering.maven.gitflowhelper;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
+
+@RunWith(BlockJUnit4ClassRunner.class)
+public class OtherBranchTest {
+
+    private final String baseVersion = "1.0.2";
+    private final String baseSnapshotVersion = "1.0.2-SNAPSHOT";
+    private final String branchName = "feature/other-branch-name";
+    private final String expectedSnapshotResult = "1.0.2+feature-other-branch-name-SNAPSHOT";
+
+    private OtherBranchVersionExtension getExtension() {
+        OtherBranchVersionExtension extension = new OtherBranchVersionExtension();
+        extension.otherBranchVersionDelimiter = "+";
+        return extension;
+    }
+
+    @Test
+    public void assertOtherBranchNameIsPrefixedBeforeSnapshot() {
+        OtherBranchVersionExtension extension = getExtension();
+        Assert.assertEquals(expectedSnapshotResult, extension.getAsBranchSnapshotVersion(baseSnapshotVersion,branchName));
+    }
+
+    @Test
+    public void assertOtherBranchNameIsOnlyPrefixedBeforeSnapshotOneTime() {
+        OtherBranchVersionExtension extension = getExtension();
+        Assert.assertEquals(expectedSnapshotResult, extension.getAsBranchSnapshotVersion(extension.getAsBranchSnapshotVersion(baseSnapshotVersion,branchName),branchName));
+    }
+}


### PR DESCRIPTION
fix an issue wherein certain plugin execution orders could lead to the other branch suffix being applied to a version repeatedly `+normalized-branch-name+normalized-branch-name-SNAPSHOT`

This is associated with issue #105 