### PR TITLE
Allow explicit configured plugins to execute on master as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,8 +332,8 @@ directly from master**. Rather, master is really only used for tracking releases
 To accomplish this the `promote-master` goal and a Maven build extension work together.
 
 With the build extension added to your project, any build where the `gitBranchExpression` matches the `masterBranchPattern` or `supportBranchPattern` will have it's
-build lifecycle (plugins, goals, etc) altered. Any plugin other than the gitflow-helper-maven-plugin, the maven-deploy-plugin, or plugins with goals
- explicitly referenced on the command line will be ignored (removed from the project reactor). 
+build lifecycle (plugins, goals, etc) altered. Any plugin other than the gitflow-helper-maven-plugin, the maven-deploy-plugin, plugins with goals
+ explicitly referenced on the command line or those configured explicitly in the `retainPlugins` list, will be ignored (removed from the project reactor). 
 This allows us to enforce the ideal that code should never be built in the master branch.
 
 The `promote-master` goal executes when the `gitBranchExpression` resolves to a value matching the `masterBranchPattern` or `supportBranchPattern` regular expression.

--- a/src/main/java/com/e_gineering/maven/gitflowhelper/PromoteMasterMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/PromoteMasterMojo.java
@@ -4,6 +4,9 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.util.List;
 
 /**
  * If the build is being executed from a DEVELOPMENT, HOTFIX or RELEASE branch, attach an artifact containing a list of
@@ -16,6 +19,15 @@ import org.apache.maven.plugins.annotations.Mojo;
  */
 @Mojo(name = "promote-master", defaultPhase = LifecyclePhase.INSTALL)
 public class PromoteMasterMojo extends AbstractGitflowBasedRepositoryMojo {
+
+    /**
+     * List of groupId:artifactId strings that refer to plugins that should be retained while building on master.
+     *
+     * Note that this property is listed here for documentation purposes, but it is handled within
+     * {@link MasterPromoteExtension}.
+     */
+    @Parameter(property = "retainPlugins")
+    private List<String> retainPlugins;
 
     @Override
     protected void execute(final GitBranchInfo gitBranchInfo) throws MojoExecutionException, MojoFailureException {

--- a/src/test/resources/project-stub/pom.xml
+++ b/src/test/resources/project-stub/pom.xml
@@ -118,7 +118,42 @@
 				<version>4.2.0</version>
 				<extensions>true</extensions>
 			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+				<version>1.2.2</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>flatten</goal>
+						</goals>
+						<phase>process-resources</phase>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>retain-configuration</id>
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>com.e-gineering</groupId>
+							<artifactId>gitflow-helper-maven-plugin</artifactId>
+							<version>${version.gitflow.plugin}</version>
+							<configuration>
+								<retainPlugins>
+									<retainPlugin>org.codehaus.mojo:flatten-maven-plugin</retainPlugin>
+								</retainPlugins>
+							</configuration>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+			</build>
+		</profile>
+	</profiles>
 
 </project>


### PR DESCRIPTION
Extended the MasterPromoteExtension to not only retain the hardcoded gitflow-helper-maven-plugin itself and the maven-deploy-plugin, or the plugins related to explicit supplied command-line goals, but also allow a project to configure additional plugins that may also execute on master/support.

This serves two cases:

1) It solves the issue #127 (though admittedly it still would be more clean to be able to download the pom file from the release repo)
2) It can serve as a basic extension point to allow other "things" to happen on a master build, that are beyond the scope of deploying maven artifacts (ie have some antrun script run)