### PR TITLE
Authentication for mirrored repos

### DIFF
--- a/src/main/java/com/e_gineering/maven/gitflowhelper/SetGitPropertiesMojo.java
+++ b/src/main/java/com/e_gineering/maven/gitflowhelper/SetGitPropertiesMojo.java
@@ -47,11 +47,7 @@ public class SetGitPropertiesMojo extends AbstractGitflowBranchMojo
             for(PropertyMapper pm : branchNamePropertyMappers)
             {
                 String mappedValue = pm.map(gitBranchInfo);
-                getLog().info("Mapper  [" + pm.getPropertyName() + "] mapped Git branch name [" + gitBranchInfo.getName() + "] to [" + mappedValue + "]");
-                if(StringUtils.isBlank(mappedValue)) {
-                    getLog().warn("Mapper for property [" + pm.getPropertyName() + "] did not provide a value, ignoring it");
-                    continue;
-                }
+                getLog().info("Mapped Git branch name [" + gitBranchInfo.getName() + "] for property [" + pm.getPropertyName() +"] to [" + mappedValue + "]");
                 project.getProperties().setProperty(pm.getPropertyName(), mappedValue);
             }
         }

--- a/src/test/java/com/e_gineering/maven/gitflowhelper/TestPropertyMapper.java
+++ b/src/test/java/com/e_gineering/maven/gitflowhelper/TestPropertyMapper.java
@@ -1,15 +1,20 @@
 package com.e_gineering.maven.gitflowhelper;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.function.BiFunction;
 
+/**
+ * Unit-Test for the class {@link PropertyMapper}
+ */
 public class TestPropertyMapper
 {
     /**
-     * Test the methode {@link PropertyMapper#map(GitBranchInfo)} with a Java Mapper
+     * Tests the methode {@link PropertyMapper#map(GitBranchInfo)} with a Java Mapper
      * @throws MojoExecutionException on error
      */
     @Test
@@ -26,7 +31,7 @@ public class TestPropertyMapper
     }
 
     /**
-     * Test the methode {@link PropertyMapper#map(GitBranchInfo)} with a Javascript Mapper
+     * Tests the methode {@link PropertyMapper#map(GitBranchInfo)} with a Javascript Mapper
      * @throws MojoExecutionException on error
      */
     @Test
@@ -46,6 +51,47 @@ public class TestPropertyMapper
         Assert.assertEquals("foo", mapper.map(info));
 
     }
+
+    /**
+     * Tests the conversion of a branch name to a valid Docker image name
+     * @throws Exception on error
+     */
+    @Test
+    public void testPropertyMapperWithJavascriptBranchNameToDockerImageNameDevelopBranch() throws Exception {
+
+        PropertyMapper mapper = new PropertyMapper();
+        mapper.setPropertyName("prop");
+        mapper.setLanguage("javascript");
+
+        mapper.setMapper(IOUtils.toString(getClass().getResource("PropertyMapperBranchNameToDockerName.js"), StandardCharsets.UTF_8));
+
+        Assert.assertEquals("", mapper.map(new GitBranchInfo("", GitBranchType.OTHER, "")));
+
+        Assert.assertEquals("foo", mapper.map(new GitBranchInfo("FOO", GitBranchType.OTHER, "")));
+        Assert.assertEquals("f_f", mapper.map(new GitBranchInfo("F_f", GitBranchType.OTHER, "")));
+        Assert.assertEquals("f_ae", mapper.map(new GitBranchInfo("F_ä", GitBranchType.OTHER, "")));
+        Assert.assertEquals("f_ae", mapper.map(new GitBranchInfo("F_Ä", GitBranchType.OTHER, "")));
+        Assert.assertEquals("f_oe", mapper.map(new GitBranchInfo("F_ö", GitBranchType.OTHER, "")));
+        Assert.assertEquals("f_oe", mapper.map(new GitBranchInfo("F_Ö", GitBranchType.OTHER, "")));
+        Assert.assertEquals("f_ue", mapper.map(new GitBranchInfo("F_ü", GitBranchType.OTHER, "")));
+        Assert.assertEquals("f_ue", mapper.map(new GitBranchInfo("F_Ü", GitBranchType.OTHER, "")));
+        Assert.assertEquals("f_ss", mapper.map(new GitBranchInfo("F_ß", GitBranchType.OTHER, "")));
+        Assert.assertEquals("f_ss", mapper.map(new GitBranchInfo("F_ß", GitBranchType.OTHER, "")));
+
+        Assert.assertEquals("f__", mapper.map(new GitBranchInfo("F_!", GitBranchType.OTHER, "")));
+        Assert.assertEquals("f__a_", mapper.map(new GitBranchInfo("F__!", GitBranchType.OTHER, "")));
+
+        Assert.assertEquals("a_f", mapper.map(new GitBranchInfo("_f", GitBranchType.OTHER, "")));
+        Assert.assertEquals("a__a_", mapper.map(new GitBranchInfo("___", GitBranchType.OTHER, "")));
+
+        Assert.assertEquals("a.a", mapper.map(new GitBranchInfo(".a", GitBranchType.OTHER, "")));
+        Assert.assertEquals("a-a", mapper.map(new GitBranchInfo("-a", GitBranchType.OTHER, "")));
+        Assert.assertEquals("a_a", mapper.map(new GitBranchInfo("_a", GitBranchType.OTHER, "")));
+
+        Assert.assertEquals("a__a", mapper.map(new GitBranchInfo("__a", GitBranchType.OTHER, "")));
+        Assert.assertEquals("a---a", mapper.map(new GitBranchInfo("---a", GitBranchType.OTHER, "")));
+    }
+
 
     public static class ToLowerCaseMapper implements BiFunction<String,String,String>
     {

--- a/src/test/resources/com/e_gineering/maven/gitflowhelper/PropertyMapperBranchNameToDockerName.js
+++ b/src/test/resources/com/e_gineering/maven/gitflowhelper/PropertyMapperBranchNameToDockerName.js
@@ -1,0 +1,117 @@
+/*
+
+ Sample Mapping for Mapping a Branchname into a Docker Image Name
+
+ Name konvention for Docker image Names see
+(see https://docs.docker.com/engine/reference/commandline/tag/#extended-description)
+
+An image name is made up of slash-separated name components, optionally prefixed by a
+registry hostname. The hostname must comply with standard DNS rules, but may not contain
+underscores. If a hostname is present, it may optionally be followed by a port number in
+the format :8080. If not present, the command uses Docker’s public registry located at
+registry-1.docker.io by default.
+Name components may contain lowercase letters, digits and separators. A separator is
+defined as a period, one or two underscores, or one or more hyphens. A name component
+may not start or end with a separator.
+*/
+
+function log(msg) {
+    //print(msg);
+}
+
+function toValidDockerNameChar(c) {
+    if(c.match(/[a-z]/i)) {
+        return c.toLowerCase();
+    }
+    if(c.match(/[0-9]/)) {
+        return c;
+    }
+    // Special handling for German Umlaute
+    switch(c) {
+        case ".":
+            return ".";
+        case "-":
+            return "-";
+        case "ä":
+            return "ae";
+        case "Ä":
+            return "ae";
+        case "ü":
+            return "ue";
+        case "Ü":
+            return "ue";
+        case "ö":
+            return "oe";
+        case 'Ö':
+            return "oe";
+        case 'ß':
+            return "ss";
+        default:
+            return "_";
+    }
+}
+function branchNameToDockerImageName(branchName) {
+    if(branchName.length === 0) {
+        return "";
+    }
+    var ret = "";
+    var firstChar = toValidDockerNameChar(branchName.charAt(0))
+    var numDots = 0;
+    var numUnderscores = 0;
+    // A name component may not start or end with a separator.
+    switch(firstChar) {
+        case '.':
+            ret += "a.";
+            numDots++;
+            break;
+        case '_':
+            ret += "a_";
+            numUnderscores++;
+            break;
+        case '-':
+            ret += "a-";
+            break;
+        default:
+            ret += firstChar;
+    }
+
+    for(var i = 1; i < branchName.length; i++) {
+        var nextChar = toValidDockerNameChar(branchName.charAt(i));
+        switch(nextChar) {
+            case '.':
+                numDots++;
+                if(numDots > 1) {
+                    ret += "a";
+                    numDots = 0;
+                }
+                ret += '.';
+                break;
+            case '_':
+                numUnderscores++;
+                if(numUnderscores > 2) {
+                    ret += "a";
+                    numUnderscores = 1;
+                }
+                ret += '_';
+                break;
+            default:
+                ret += nextChar;
+                numUnderscores = 0;
+                numDots = 0;
+        }
+    }
+    log("ret: " + ret);
+
+    return ret;
+}
+
+
+function map(branchName, branchType) {
+    log("branchName: [" + branchName + "], branchType=[" + branchType + "]");
+    switch(branchType.toString()) {
+        case 'OTHER':
+            return branchNameToDockerImageName(branchName.trim());
+        default:
+            return "";
+    }
+}


### PR DESCRIPTION
With PR #132 I introduces a bug. When AbstractGitflowBasedRepositoryMojo#getDeploymentRepository returns a mirrored artifact, then the authentication object must be injected.
